### PR TITLE
Feat/rabbit 13 bunny name duplicate check api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,8 +26,8 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
+//	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+//	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'

--- a/src/main/java/team/avgmax/rabbit/bunny/entity/enums/BunnyType.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/entity/enums/BunnyType.java
@@ -1,7 +1,34 @@
 package team.avgmax.rabbit.bunny.entity.enums;
 
+import java.math.BigDecimal;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public enum BunnyType {
-    A,
-    B,
-    C
+    A(
+        "희소 자산형",
+        BigDecimal.valueOf(100_000_000),
+        BigDecimal.valueOf(1_000),
+        BigDecimal.valueOf(100_000)
+    ),
+    B(
+        "밸런스형",
+        BigDecimal.valueOf(10_000_000),
+        BigDecimal.valueOf(100_000),
+        BigDecimal.valueOf(1_000)
+    ),
+    C(
+        "단가 친화형",
+        BigDecimal.valueOf(10_000_000),
+        BigDecimal.valueOf(1_000_000),
+        BigDecimal.valueOf(100)
+    );
+
+    private final String displayName;
+    private final BigDecimal marketCap;  // 시총 (C)
+    private final BigDecimal totalSupply; // 개수 (BNY)
+    private final BigDecimal price;      // 단가 (C)
 }

--- a/src/main/java/team/avgmax/rabbit/bunny/repository/BunnyRepository.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/repository/BunnyRepository.java
@@ -4,4 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import team.avgmax.rabbit.bunny.entity.Bunny;
 
 public interface BunnyRepository extends JpaRepository<Bunny, String> {
+    boolean existsByBunnyName(String bunnyName);
 }

--- a/src/main/java/team/avgmax/rabbit/funding/controller/FundingController.java
+++ b/src/main/java/team/avgmax/rabbit/funding/controller/FundingController.java
@@ -1,15 +1,22 @@
 package team.avgmax.rabbit.funding.controller;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import team.avgmax.rabbit.funding.service.FundingService;
 import team.avgmax.rabbit.funding.dto.request.CreateFundBunnyRequest;
+import team.avgmax.rabbit.funding.dto.response.FundBunnyListResponse;
 import team.avgmax.rabbit.funding.dto.response.FundBunnyResponse;
 
 @Slf4j
@@ -19,10 +26,30 @@ public class FundingController {
 
     private final FundingService fundingService;
 
+    // 버니 이름 중복 체크
+    @RequestMapping(value = "/fund-bunnies/{bunnyName}", method = RequestMethod.HEAD)
+    public ResponseEntity<Void> checkBunnyName(@PathVariable String bunnyName) {
+        boolean isDuplicate = fundingService.checkDuplicateBunnyName(bunnyName);
+        return isDuplicate ? ResponseEntity.status(HttpStatus.CONFLICT).build() : ResponseEntity.ok().build();
+    }
+
+    // 버니 심사 요청
     @PostMapping("/fund-bunnies")
     public ResponseEntity<FundBunnyResponse> createFundBunnies(@RequestBody CreateFundBunnyRequest request) {
         // 임시 user
         String userId = "01HZX1T5F5QW4Z8E7T9C6K3M1N";
         return ResponseEntity.ok(fundingService.createFundBunny(request, userId));
     }
+
+    // // 펀딩 중인 버니 목록 조회
+    // @GetMapping("/fund-bunnies")
+    // public ResponseEntity<FundBunnyListResponse> getFundBunnyList(@RequestParam(required = false) Boolean endingSoon) {
+    //     return ResponseEntity.ok(fundingService.getFundBunnyList(endingSoon));
+    // }
+
+    // // 펀딩 중인 버니 상세 조회
+    // @GetMapping("/fund-bunnies/{fundBunnyId}")
+    // public ResponseEntity<FundBunnyResponse> getFundBunny(@PathVariable String fundBunnyId) {
+    //     return ResponseEntity.ok(fundingService.getFundBunny(fundBunnyId));
+    // }
 }

--- a/src/main/java/team/avgmax/rabbit/funding/controller/FundingController.java
+++ b/src/main/java/team/avgmax/rabbit/funding/controller/FundingController.java
@@ -1,11 +1,16 @@
 package team.avgmax.rabbit.funding.controller;
 
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import team.avgmax.rabbit.funding.service.FundingService;
+import team.avgmax.rabbit.funding.dto.request.CreateFundBunnyRequest;
+import team.avgmax.rabbit.funding.dto.response.FundBunnyResponse;
 
 @Slf4j
 @RestController
@@ -13,4 +18,11 @@ import team.avgmax.rabbit.funding.service.FundingService;
 public class FundingController {
 
     private final FundingService fundingService;
+
+    @PostMapping("/fund-bunnies")
+    public ResponseEntity<FundBunnyResponse> createFundBunnies(@RequestBody CreateFundBunnyRequest request) {
+        // 임시 user
+        String userId = "01HZX1T5F5QW4Z8E7T9C6K3M1N";
+        return ResponseEntity.ok(fundingService.createFundBunny(request, userId));
+    }
 }

--- a/src/main/java/team/avgmax/rabbit/funding/dto/request/CreateFundBunnyRequest.java
+++ b/src/main/java/team/avgmax/rabbit/funding/dto/request/CreateFundBunnyRequest.java
@@ -1,0 +1,15 @@
+package team.avgmax.rabbit.funding.dto.request;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import lombok.Builder;
+import team.avgmax.rabbit.bunny.entity.enums.BunnyType;
+
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record CreateFundBunnyRequest(
+    String bunnyName,
+    BunnyType bunnyType
+) {
+}

--- a/src/main/java/team/avgmax/rabbit/funding/dto/response/FundBunnyListResponse.java
+++ b/src/main/java/team/avgmax/rabbit/funding/dto/response/FundBunnyListResponse.java
@@ -1,0 +1,22 @@
+package team.avgmax.rabbit.funding.dto.response;
+
+import java.util.List;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import lombok.Builder;
+
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record FundBunnyListResponse(
+    long totalCount,
+    List<FundBunnyResponse> fundBunnies
+) {
+    public static FundBunnyListResponse of(List<FundBunnyResponse> fundBunnies) {
+        return FundBunnyListResponse.builder()
+                .totalCount(fundBunnies.size())
+                .fundBunnies(fundBunnies)
+                .build();
+    }
+}

--- a/src/main/java/team/avgmax/rabbit/funding/dto/response/FundBunnyResponse.java
+++ b/src/main/java/team/avgmax/rabbit/funding/dto/response/FundBunnyResponse.java
@@ -1,0 +1,38 @@
+package team.avgmax.rabbit.funding.dto.response;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import lombok.Builder;
+
+import team.avgmax.rabbit.bunny.entity.enums.BunnyType;
+import team.avgmax.rabbit.funding.entity.FundBunny;
+
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record FundBunnyResponse(
+    String fundBunnyId,
+    String userId,
+    String bunnyName,
+    BunnyType bunnyType,
+    BigDecimal marketCap,
+    BigDecimal totalSupply,
+    BigDecimal price,
+    LocalDateTime createdAt
+) {
+    public static FundBunnyResponse from(FundBunny fundBunny) {
+        return FundBunnyResponse.builder()
+                .fundBunnyId(fundBunny.getId())
+                .userId(fundBunny.getUser().getId())
+                .bunnyName(fundBunny.getBunnyName())
+                .bunnyType(fundBunny.getType())
+                .marketCap(fundBunny.getType().getMarketCap())
+                .totalSupply(fundBunny.getType().getTotalSupply())
+                .price(fundBunny.getType().getPrice())
+                .createdAt(fundBunny.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/team/avgmax/rabbit/funding/entity/FundBunny.java
+++ b/src/main/java/team/avgmax/rabbit/funding/entity/FundBunny.java
@@ -2,6 +2,7 @@ package team.avgmax.rabbit.funding.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import team.avgmax.rabbit.funding.dto.request.CreateFundBunnyRequest;
 import team.avgmax.rabbit.global.entity.BaseTime;
 import team.avgmax.rabbit.global.util.UlidGenerator;
 import team.avgmax.rabbit.user.entity.PersonalUser;
@@ -32,9 +33,18 @@ public class FundBunny extends BaseTime {
     @Enumerated(EnumType.STRING)
     private BunnyType type;
 
+    @Builder.Default
     @Enumerated(EnumType.STRING)
-    private FundBunnyStatus status;
+    private FundBunnyStatus status = FundBunnyStatus.ONGOING;
 
-    private BigDecimal backerCount;
+    @Builder.Default
+    private BigDecimal backerCount = BigDecimal.ZERO;
 
+    public static FundBunny create(CreateFundBunnyRequest request, PersonalUser user) {
+        return FundBunny.builder()
+                .user(user)
+                .bunnyName(request.bunnyName())
+                .type(request.bunnyType())
+                .build();
+    }
 }

--- a/src/main/java/team/avgmax/rabbit/funding/exception/FundingError.java
+++ b/src/main/java/team/avgmax/rabbit/funding/exception/FundingError.java
@@ -1,0 +1,24 @@
+package team.avgmax.rabbit.funding.exception;
+
+import org.springframework.http.HttpStatus;
+
+import team.avgmax.rabbit.global.dto.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum FundingError implements ErrorCode {
+    BUNNY_NAME_REQUIRED(HttpStatus.BAD_REQUEST, "버니 이름은 필수입니다."),
+    BUNNY_NAME_DUPLICATE(HttpStatus.BAD_REQUEST, "이미 존재하는 버니 이름입니다."),
+    BUNNY_NAME_INVALID_LENGTH(HttpStatus.BAD_REQUEST, "버니 이름은 3자 이상 20자 이하여야 합니다."),
+    BUNNY_NAME_INVALID_HYPHEN_START_END(HttpStatus.BAD_REQUEST, "버니 이름은 하이픈으로 시작하거나 끝날 수 없습니다."),
+    BUNNY_NAME_INVALID_CONSECUTIVE_HYPHEN(HttpStatus.BAD_REQUEST, "연속된 하이픈은 사용할 수 없습니다."),
+    BUNNY_NAME_INVALID_CHARACTER(HttpStatus.BAD_REQUEST, "버니 이름은 영어 소문자, 숫자, 하이픈만 사용할 수 있습니다."),
+    BUNNY_TYPE_REQUIRED(HttpStatus.BAD_REQUEST, "버니 타입은 필수입니다."),
+    BUNNY_TYPE_INVALID(HttpStatus.BAD_REQUEST, "지원하지 않는 버니 타입입니다. A, B, C 중 하나를 선택해주세요.");
+
+    private final HttpStatus status;
+    private final String message;
+
+}

--- a/src/main/java/team/avgmax/rabbit/funding/exception/FundingException.java
+++ b/src/main/java/team/avgmax/rabbit/funding/exception/FundingException.java
@@ -1,0 +1,15 @@
+package team.avgmax.rabbit.funding.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class FundingException extends RuntimeException {
+    private final FundingError error;
+    
+    @Override
+    public String getMessage() {
+        return error.getMessage();
+    }
+}

--- a/src/main/java/team/avgmax/rabbit/funding/repository/FundBunnyRepository.java
+++ b/src/main/java/team/avgmax/rabbit/funding/repository/FundBunnyRepository.java
@@ -1,0 +1,8 @@
+package team.avgmax.rabbit.funding.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import team.avgmax.rabbit.funding.entity.FundBunny;
+
+public interface FundBunnyRepository extends JpaRepository<FundBunny, String> {
+    boolean existsByBunnyName(String bunnyName);
+}

--- a/src/main/java/team/avgmax/rabbit/funding/service/FundingService.java
+++ b/src/main/java/team/avgmax/rabbit/funding/service/FundingService.java
@@ -30,7 +30,9 @@ public class FundingService {
     public FundBunnyResponse createFundBunny(CreateFundBunnyRequest request, String userId) {
         validateBunnyName(request.bunnyName());
         validateBunnyType(request.bunnyType());
-        checkDuplicateBunnyName(request.bunnyName());
+        if (checkDuplicateBunnyName(request.bunnyName())) {
+            throw new FundingException(FundingError.BUNNY_NAME_DUPLICATE);
+        }
         
         PersonalUser user = userService.findPersonalUserById(userId);
         FundBunny fundBunny = FundBunny.create(request, user);
@@ -39,11 +41,7 @@ public class FundingService {
 
     @Transactional(readOnly = true)
     public boolean checkDuplicateBunnyName(String bunnyName) {
-        boolean isDuplicate = fundBunnyRepository.existsByBunnyName(bunnyName) || bunnyRepository.existsByBunnyName(bunnyName);
-        if (isDuplicate) {
-            throw new FundingException(FundingError.BUNNY_NAME_DUPLICATE);
-        }
-        return isDuplicate;
+        return fundBunnyRepository.existsByBunnyName(bunnyName) || bunnyRepository.existsByBunnyName(bunnyName);
     }
     
     private void validateBunnyName(String bunnyName) {

--- a/src/main/java/team/avgmax/rabbit/funding/service/FundingService.java
+++ b/src/main/java/team/avgmax/rabbit/funding/service/FundingService.java
@@ -1,13 +1,77 @@
 package team.avgmax.rabbit.funding.service;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
-import team.avgmax.rabbit.funding.repository.FundingRepository;
+import team.avgmax.rabbit.funding.dto.request.CreateFundBunnyRequest;
+import team.avgmax.rabbit.funding.dto.response.FundBunnyResponse;
+import team.avgmax.rabbit.funding.entity.FundBunny;
+import team.avgmax.rabbit.funding.exception.FundingError;
+import team.avgmax.rabbit.funding.exception.FundingException;
+import team.avgmax.rabbit.bunny.repository.BunnyRepository;
+import team.avgmax.rabbit.funding.repository.FundBunnyRepository;
+import team.avgmax.rabbit.user.service.UserService;
+import team.avgmax.rabbit.user.entity.PersonalUser;
+import team.avgmax.rabbit.bunny.entity.enums.BunnyType;
+
+import java.util.regex.Pattern;
+import java.util.Arrays;
 
 @Service
 @RequiredArgsConstructor
 public class FundingService {
+    private final UserService userService;
 
-    private final FundingRepository fundingRepository;
+    private final FundBunnyRepository fundBunnyRepository;
+    private final BunnyRepository bunnyRepository;
+
+    @Transactional
+    public FundBunnyResponse createFundBunny(CreateFundBunnyRequest request, String userId) {
+        validateBunnyName(request.bunnyName());
+        validateBunnyType(request.bunnyType());
+        checkDuplicateBunnyName(request.bunnyName());
+        
+        PersonalUser user = userService.findPersonalUserById(userId);
+        FundBunny fundBunny = FundBunny.create(request, user);
+        return FundBunnyResponse.from(fundBunnyRepository.save(fundBunny));
+    }
+
+    @Transactional(readOnly = true)
+    public boolean checkDuplicateBunnyName(String bunnyName) {
+        boolean isDuplicate = fundBunnyRepository.existsByBunnyName(bunnyName) || bunnyRepository.existsByBunnyName(bunnyName);
+        if (isDuplicate) {
+            throw new FundingException(FundingError.BUNNY_NAME_DUPLICATE);
+        }
+        return isDuplicate;
+    }
+    
+    private void validateBunnyName(String bunnyName) {
+        if (bunnyName == null || bunnyName.trim().isEmpty()) {
+            throw new FundingException(FundingError.BUNNY_NAME_REQUIRED);
+        }
+        if (bunnyName.length() < 3 || bunnyName.length() > 20) {
+            throw new FundingException(FundingError.BUNNY_NAME_INVALID_LENGTH);
+        }
+        if (bunnyName.startsWith("-") || bunnyName.endsWith("-")) {
+            throw new FundingException(FundingError.BUNNY_NAME_INVALID_HYPHEN_START_END);
+        }
+        if (bunnyName.contains("--")) {
+            throw new FundingException(FundingError.BUNNY_NAME_INVALID_CONSECUTIVE_HYPHEN);
+        }
+        if (!Pattern.compile("^[a-z0-9]([a-z0-9-]*[a-z0-9])?$").matcher(bunnyName).matches()) {
+            throw new FundingException(FundingError.BUNNY_NAME_INVALID_CHARACTER);
+        }
+    }
+    
+    private void validateBunnyType(BunnyType bunnyType) {
+        if (bunnyType == null) {
+            throw new FundingException(FundingError.BUNNY_TYPE_REQUIRED);
+        }
+        
+        if (!Arrays.asList(BunnyType.values()).contains(bunnyType)) {
+            throw new FundingException(FundingError.BUNNY_TYPE_INVALID);
+        }
+    }
+
 }

--- a/src/main/java/team/avgmax/rabbit/global/config/SecurityConfig.java
+++ b/src/main/java/team/avgmax/rabbit/global/config/SecurityConfig.java
@@ -1,9 +1,42 @@
-package team.avgmax.rabbit.global.config;
-
-import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-
-@Configuration
-@EnableWebSecurity
-public class SecurityConfig {
-}
+//package team.avgmax.rabbit.global.config;
+//
+//import org.springframework.context.annotation.Bean;
+//import org.springframework.context.annotation.Configuration;
+//import org.springframework.http.HttpMethod;
+//import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+//import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+//import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+//import org.springframework.security.config.http.SessionCreationPolicy;
+//import org.springframework.security.web.SecurityFilterChain;
+//
+//@Configuration
+//@EnableWebSecurity
+//public class SecurityConfig {
+//
+//    @Bean
+//    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+//        //csrf disable
+//        http
+//                .csrf(AbstractHttpConfigurer::disable);
+//
+//        //From 로그인 방식 disable
+//        http
+//                .formLogin(AbstractHttpConfigurer::disable);
+//
+//        //HTTP Basic 인증 방식 disable
+//        http
+//                .httpBasic(AbstractHttpConfigurer::disable);
+//
+//        //경로별 인가 작업
+//        http
+//                .authorizeHttpRequests((auth) -> auth
+//                        .requestMatchers(HttpMethod.POST, "/fund-bunnies").permitAll()
+//                        .anyRequest().authenticated());
+//        //세션 설정 : STATELESS
+//        http
+//                .sessionManagement((session) -> session
+//                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+//
+//        return http.build();
+//    }
+//}

--- a/src/main/java/team/avgmax/rabbit/global/dto/ErrorCode.java
+++ b/src/main/java/team/avgmax/rabbit/global/dto/ErrorCode.java
@@ -1,0 +1,9 @@
+package team.avgmax.rabbit.global.dto;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+    HttpStatus getStatus();
+    String name();
+    String getMessage();
+}

--- a/src/main/java/team/avgmax/rabbit/global/dto/ErrorResponse.java
+++ b/src/main/java/team/avgmax/rabbit/global/dto/ErrorResponse.java
@@ -1,0 +1,22 @@
+package team.avgmax.rabbit.global.dto;
+
+import org.springframework.http.ResponseEntity;
+
+import lombok.Builder;
+
+@Builder
+public record ErrorResponse(
+    int status,
+    String name,
+    String message
+) {
+    public static ResponseEntity<ErrorResponse> toResponseEntity(ErrorCode e){
+        return ResponseEntity
+                .status(e.getStatus())
+                .body(ErrorResponse.builder()
+                		.status(e.getStatus().value())
+                        .name(e.name())
+                        .message(e.getMessage())
+                        .build());
+    }
+}

--- a/src/main/java/team/avgmax/rabbit/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/team/avgmax/rabbit/global/handler/GlobalExceptionHandler.java
@@ -1,0 +1,48 @@
+package team.avgmax.rabbit.global.handler;
+
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+//import org.springframework.security.core.AuthenticationException;
+//import org.springframework.security.access.AccessDeniedException;
+
+import team.avgmax.rabbit.global.dto.ErrorResponse;
+import team.avgmax.rabbit.funding.exception.FundingException;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+    // UserException 처리
+
+    // BunnyException 처리
+
+    // FundingException 처리
+    @ExceptionHandler(FundingException.class)
+    public ResponseEntity<ErrorResponse> handleFundingException(FundingException ex) {
+        return ErrorResponse.toResponseEntity(ex.getError());
+    }
+
+    // IllegalStateException 처리
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<Object> handleIllegalStateException(IllegalStateException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
+    }
+
+//    // Unauthentication 처리
+//    @ExceptionHandler(AuthenticationException.class)
+//    public ResponseEntity<Object> handleAuthenticationException(AuthenticationException ex) {
+//        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ex.getMessage());
+//    }
+//
+//    // Authorization 처리
+//    @ExceptionHandler(AccessDeniedException.class)
+//    public ResponseEntity<Object> handleAccessDeniedException(AccessDeniedException ex) {
+//        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ex.getMessage());
+//    }
+
+    // 기타 모든 예외 처리 (500 서버 에러)
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Object> handleException(Exception ex) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(ex.getMessage());
+    }
+}

--- a/src/main/java/team/avgmax/rabbit/user/entity/User.java
+++ b/src/main/java/team/avgmax/rabbit/user/entity/User.java
@@ -23,6 +23,7 @@ public class User extends BaseTime {
 
     private String image;
 
+    @Enumerated(EnumType.STRING)
     private Role role;
     
     private String phone;

--- a/src/main/java/team/avgmax/rabbit/user/exception/UserError.java
+++ b/src/main/java/team/avgmax/rabbit/user/exception/UserError.java
@@ -1,0 +1,15 @@
+package team.avgmax.rabbit.user.exception;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserError {
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/team/avgmax/rabbit/user/exception/UserException.java
+++ b/src/main/java/team/avgmax/rabbit/user/exception/UserException.java
@@ -1,0 +1,16 @@
+package team.avgmax.rabbit.user.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import team.avgmax.rabbit.funding.exception.FundingError;
+
+@Getter
+@RequiredArgsConstructor
+public class UserException extends RuntimeException {
+    private final UserError error;
+
+    @Override
+    public String getMessage() {
+        return error.getMessage();
+    }
+}

--- a/src/main/java/team/avgmax/rabbit/user/repository/PersonalUserRepository.java
+++ b/src/main/java/team/avgmax/rabbit/user/repository/PersonalUserRepository.java
@@ -4,5 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import team.avgmax.rabbit.user.entity.PersonalUser;
 
-public interface PersonalUserRepository extends JpaRepository<PersonalUser, String> {   
+public interface PersonalUserRepository extends JpaRepository<PersonalUser, String> {
 }

--- a/src/main/java/team/avgmax/rabbit/user/service/UserService.java
+++ b/src/main/java/team/avgmax/rabbit/user/service/UserService.java
@@ -3,6 +3,9 @@ package team.avgmax.rabbit.user.service;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
+import team.avgmax.rabbit.user.entity.PersonalUser;
+import team.avgmax.rabbit.user.exception.UserError;
+import team.avgmax.rabbit.user.exception.UserException;
 import team.avgmax.rabbit.user.repository.PersonalUserRepository;
 
 @Service
@@ -10,4 +13,9 @@ import team.avgmax.rabbit.user.repository.PersonalUserRepository;
 public class UserService {
 
     private final PersonalUserRepository personalUserRepository;
+
+    public PersonalUser findPersonalUserById(String userId) {
+        return personalUserRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserError.USER_NOT_FOUND));
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,7 +11,7 @@ spring:
   jpa:
     generate-ddl: true
     hibernate:
-      ddl-auto: create 
+      ddl-auto: create
     properties:
       hibernate:
         format_sql: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,7 +11,7 @@ spring:
   jpa:
     generate-ddl: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true

--- a/src/test/java/team/avgmax/rabbit/funding/service/FundingServiceTest.java
+++ b/src/test/java/team/avgmax/rabbit/funding/service/FundingServiceTest.java
@@ -1,0 +1,297 @@
+package team.avgmax.rabbit.funding.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import team.avgmax.rabbit.bunny.entity.enums.BunnyType;
+import team.avgmax.rabbit.funding.dto.request.CreateFundBunnyRequest;
+import team.avgmax.rabbit.funding.dto.response.FundBunnyResponse;
+import team.avgmax.rabbit.funding.entity.FundBunny;
+import team.avgmax.rabbit.funding.entity.enums.FundBunnyStatus;
+import team.avgmax.rabbit.funding.exception.FundingException;
+import team.avgmax.rabbit.funding.exception.FundingError;
+import team.avgmax.rabbit.funding.repository.FundBunnyRepository;
+import team.avgmax.rabbit.bunny.repository.BunnyRepository;
+import team.avgmax.rabbit.user.entity.PersonalUser;
+import team.avgmax.rabbit.user.service.UserService;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class FundingServiceTest {
+
+    @InjectMocks
+    private FundingService fundingService;
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private FundBunnyRepository fundBunnyRepository;
+    
+    @Mock
+    private BunnyRepository bunnyRepository;
+
+    @Test
+    void createFundBunny_유효한요청_펀드버니생성성공() {
+        // given
+        String bunnyName = "valid-bunny";
+        BunnyType bunnyType = BunnyType.A;
+        String userId = "test-user-id";
+        
+        CreateFundBunnyRequest request = new CreateFundBunnyRequest(bunnyName, bunnyType);
+        PersonalUser user = PersonalUser.builder()
+                .id(userId)
+                .build();
+        
+        FundBunny savedFundBunny = FundBunny.builder()
+                .id("fund-bunny-id")
+                .user(user)
+                .bunnyName(bunnyName)
+                .type(bunnyType)
+                .status(FundBunnyStatus.ONGOING)
+                .backerCount(BigDecimal.ZERO)
+                .build();
+        
+        when(fundingService.checkDuplicateBunnyName(bunnyName)).thenReturn(false);
+        when(fundBunnyRepository.save(any(FundBunny.class))).thenReturn(savedFundBunny);
+        
+        // when
+        FundBunnyResponse result = fundingService.createFundBunny(request, user.getId());
+        
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.fundBunnyId()).isEqualTo("fund-bunny-id");
+        assertThat(result.userId()).isEqualTo(userId);
+        assertThat(result.bunnyName()).isEqualTo(bunnyName);
+        assertThat(result.bunnyType()).isEqualTo(bunnyType);
+    }
+
+    // bunnyName 양식 오류 테스트 케이스들
+    
+    @Test
+    void createFundBunny_null버니이름_예외발생() {
+        // given
+        CreateFundBunnyRequest request = new CreateFundBunnyRequest(null, BunnyType.A);
+        PersonalUser user = PersonalUser.builder().id("test-user").build();
+        
+        // when & then
+        assertThatThrownBy(() -> fundingService.createFundBunny(request, user.getId()))
+                .isInstanceOf(FundingException.class)
+                .hasMessage(FundingError.BUNNY_NAME_REQUIRED.getMessage());
+    }
+
+    @Test
+    void createFundBunny_빈문자열버니이름_예외발생() {
+        // given
+        CreateFundBunnyRequest request = new CreateFundBunnyRequest("", BunnyType.A);
+        PersonalUser user = PersonalUser.builder().id("test-user").build();
+        
+        // when & then
+        assertThatThrownBy(() -> fundingService.createFundBunny(request, user.getId()))
+                .isInstanceOf(FundingException.class)
+                .hasMessage(FundingError.BUNNY_NAME_REQUIRED.getMessage());
+    }
+
+    @Test
+    void createFundBunny_짧은버니이름_예외발생() {
+        // given
+        CreateFundBunnyRequest request = new CreateFundBunnyRequest("ab", BunnyType.A);
+        PersonalUser user = PersonalUser.builder().id("test-user").build();
+        
+        // when & then
+        assertThatThrownBy(() -> fundingService.createFundBunny(request, user.getId()))
+                .isInstanceOf(FundingException.class)
+                .hasMessage(FundingError.BUNNY_NAME_INVALID_LENGTH.getMessage());
+    }
+
+    @Test
+    void createFundBunny_긴버니이름_예외발생() {
+        // given
+        CreateFundBunnyRequest request = new CreateFundBunnyRequest("a".repeat(21), BunnyType.A);
+        PersonalUser user = PersonalUser.builder().id("test-user").build();
+        
+        // when & then
+        assertThatThrownBy(() -> fundingService.createFundBunny(request, user.getId()))
+                .isInstanceOf(FundingException.class)
+                .hasMessage(FundingError.BUNNY_NAME_INVALID_LENGTH.getMessage());
+    }
+
+    @Test
+    void createFundBunny_하이픈시작버니이름_예외발생() {
+        // given
+        CreateFundBunnyRequest request = new CreateFundBunnyRequest("-invalid", BunnyType.A);
+        PersonalUser user = PersonalUser.builder().id("test-user").build();
+        
+        // when & then
+        assertThatThrownBy(() -> fundingService.createFundBunny(request, user.getId()))
+                .isInstanceOf(FundingException.class)
+                .hasMessage(FundingError.BUNNY_NAME_INVALID_HYPHEN_START_END.getMessage());
+    }
+
+    @Test
+    void createFundBunny_하이픈끝버니이름_예외발생() {
+        // given
+        CreateFundBunnyRequest request = new CreateFundBunnyRequest("invalid-", BunnyType.A);
+        PersonalUser user = PersonalUser.builder().id("test-user").build();
+        
+        // when & then
+        assertThatThrownBy(() -> fundingService.createFundBunny(request, user.getId()))
+                .isInstanceOf(FundingException.class)
+                .hasMessage(FundingError.BUNNY_NAME_INVALID_HYPHEN_START_END.getMessage());
+    }
+
+    @Test
+    void createFundBunny_연속하이픈버니이름_예외발생() {
+        // given
+        CreateFundBunnyRequest request = new CreateFundBunnyRequest("dev--team", BunnyType.A);
+        PersonalUser user = PersonalUser.builder().id("test-user").build();
+        
+        // when & then
+        assertThatThrownBy(() -> fundingService.createFundBunny(request, user.getId()))
+                .isInstanceOf(FundingException.class)
+                .hasMessage(FundingError.BUNNY_NAME_INVALID_CONSECUTIVE_HYPHEN.getMessage());
+    }
+
+    @Test
+    void createFundBunny_대문자포함버니이름_예외발생() {
+        // given
+        CreateFundBunnyRequest request = new CreateFundBunnyRequest("InvalidName", BunnyType.A);
+        PersonalUser user = PersonalUser.builder().id("test-user").build();
+        
+        // when & then
+        assertThatThrownBy(() -> fundingService.createFundBunny(request, user.getId()))
+                .isInstanceOf(FundingException.class)
+                .hasMessage(FundingError.BUNNY_NAME_INVALID_CHARACTER.getMessage());
+    }
+
+    @Test
+    void createFundBunny_특수문자포함버니이름_예외발생() {
+        // given
+        CreateFundBunnyRequest request = new CreateFundBunnyRequest("invalid@name", BunnyType.A);
+        PersonalUser user = PersonalUser.builder().id("test-user").build();
+        
+        // when & then
+        assertThatThrownBy(() -> fundingService.createFundBunny(request, user.getId()))
+                .isInstanceOf(FundingException.class)
+                .hasMessage(FundingError.BUNNY_NAME_INVALID_CHARACTER.getMessage());
+    }
+
+    @Test
+    void createFundBunny_중복버니이름_예외발생() {
+        // given
+        // PersonalUser savedUser = PersonalUser.builder().id("test-user1").build();
+        PersonalUser newUser = PersonalUser.builder().id("test-user2").build();
+        
+        // FundBunny savedFundBunny = FundBunny.builder()
+        //         .id("fund-bunny-id")
+        //         .user(savedUser)
+        //         .bunnyName("duplicate-name")
+        //         .type(BunnyType.A)
+        //         .status(FundBunnyStatus.ONGOING)
+        //         .backerCount(BigDecimal.ZERO)
+        //         .build();
+        CreateFundBunnyRequest newRequest = CreateFundBunnyRequest.builder()
+                .bunnyName("duplicate-name")
+                .bunnyType(BunnyType.B)
+                .build();
+
+        when(fundBunnyRepository.existsByBunnyName("duplicate-name")).thenReturn(true);
+        
+        // when & then
+        assertThatThrownBy(() -> fundingService.createFundBunny(newRequest, newUser.getId()))
+                .isInstanceOf(FundingException.class)
+                .hasMessage(FundingError.BUNNY_NAME_DUPLICATE.getMessage());
+        
+    }
+
+    // BunnyType 유효성 검증 테스트 케이스들
+
+    @Test
+    void createFundBunny_null버니타입_예외발생() {
+        // given
+        CreateFundBunnyRequest request = new CreateFundBunnyRequest("valid-name", null);
+        PersonalUser user = PersonalUser.builder().id("test-user").build();
+        
+        // when & then
+        assertThatThrownBy(() -> fundingService.createFundBunny(request, user.getId()))
+                .isInstanceOf(FundingException.class)
+                .hasMessage(FundingError.BUNNY_TYPE_REQUIRED.getMessage());
+    }
+
+    @Test
+    void createFundBunny_B타입유효요청_생성성공() {
+        // given
+        String bunnyName = "balance-bunny";
+        BunnyType bunnyType = BunnyType.B;
+        String userId = "test-user-id";
+        
+        CreateFundBunnyRequest request = new CreateFundBunnyRequest(bunnyName, bunnyType);
+        PersonalUser user = PersonalUser.builder()
+                .id(userId)
+                .build();
+        
+        FundBunny savedFundBunny = FundBunny.builder()
+                .id("fund-bunny-id")
+                .user(user)
+                .bunnyName(bunnyName)
+                .type(bunnyType)
+                .status(FundBunnyStatus.ONGOING)
+                .backerCount(BigDecimal.ZERO)
+                .build();
+        
+        when(fundingService.checkDuplicateBunnyName(bunnyName)).thenReturn(false);
+        when(fundBunnyRepository.save(any(FundBunny.class))).thenReturn(savedFundBunny);
+        
+        // when
+        FundBunnyResponse result = fundingService.createFundBunny(request, user.getId());
+        
+        // then
+        assertThat(result.bunnyType()).isEqualTo(BunnyType.B);
+        assertThat(result.marketCap()).isEqualTo(BigDecimal.valueOf(10_000_000));
+        assertThat(result.totalSupply()).isEqualTo(BigDecimal.valueOf(100_000));
+        assertThat(result.price()).isEqualTo(BigDecimal.valueOf(1_000));
+    }
+
+    @Test
+    void createFundBunny_C타입유효요청_생성성공() {
+        // given
+        String bunnyName = "cheap-bunny";
+        BunnyType bunnyType = BunnyType.C;
+        String userId = "test-user-id";
+        
+        CreateFundBunnyRequest request = new CreateFundBunnyRequest(bunnyName, bunnyType);
+        PersonalUser user = PersonalUser.builder()
+                .id(userId)
+                .build();
+        
+        FundBunny savedFundBunny = FundBunny.builder()
+                .id("fund-bunny-id")
+                .user(user)
+                .bunnyName(bunnyName)
+                .type(bunnyType)
+                .status(FundBunnyStatus.ONGOING)
+                .backerCount(BigDecimal.ZERO)
+                .build();
+        
+        when(fundingService.checkDuplicateBunnyName(bunnyName)).thenReturn(false);
+        when(fundBunnyRepository.save(any(FundBunny.class))).thenReturn(savedFundBunny);
+        
+        // when
+        FundBunnyResponse result = fundingService.createFundBunny(request, user.getId());
+        
+        // then
+        assertThat(result.bunnyType()).isEqualTo(BunnyType.C);
+        assertThat(result.marketCap()).isEqualTo(BigDecimal.valueOf(10_000_000));
+        assertThat(result.totalSupply()).isEqualTo(BigDecimal.valueOf(1_000_000));
+        assertThat(result.price()).isEqualTo(BigDecimal.valueOf(100));
+    }
+}


### PR DESCRIPTION
## 📌 작업 개요
- 버니 이름 중복 확인 API 구현

## ✅ 작업 상세
- 기존에 사용한 버니 이름 중복 체크 로직을 이용해 API를 만들었습니다.
- HEAD 요청(HTTP메서드)는 GET과 유사하지만 ResponseBody 없이 헤더만 응답하기 때문에 가볍고 빠르다고 합니다. 그래서 중복 확인 용도로 사용해봤습니다.
- 이미 존재하는 이름 => 409 CONFLICT
- 사용 가능한 이름 => 200 OK

## 🎫 관련 이슈
- [RABBIT-13](https://dssw5.atlassian.net/browse/RABBIT-13)

## 🎬 참고 이미지
<img width="955" height="237" alt="스크린샷 2025-09-08 20 09 26" src="https://github.com/user-attachments/assets/958f5678-8dca-4b20-8b8c-d7ebc348376e" />
<img width="967" height="236" alt="스크린샷 2025-09-08 20 09 37" src="https://github.com/user-attachments/assets/da3707c3-3dea-4561-a8b9-4edb2b205265" />

## 📎 기타
- 인증 구현 전 테스트를 용이하게 하기 위해 Security 관련 의존성 주석처리했습니다.
- 로컬의 test db를 반복사용하기 위해 ddl-auto 옵션을 update로 수정했습니다.