### PR TITLE
fix:[RABBIT-18] 개인 사용자 인가 시 URL 기반 RBAC 기능 수정 및 logout 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,11 +29,12 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
-
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
-	implementation 'com.mysql:mysql-connector-j:9.4.0'
-	
+	// implementation 'com.mysql:mysql-connector-j:9.4.0'
+		
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/team/avgmax/rabbit/auth/controller/AuthController.java
+++ b/src/main/java/team/avgmax/rabbit/auth/controller/AuthController.java
@@ -55,7 +55,7 @@ public class AuthController {
                     .issuedAt(now)
                     .expiresAt(now.plusSeconds(accessExpiry))
                     .subject(jwt.getSubject())
-                    // ⚠️ refresh 토큰에 roles 안 넣었다면, DB 조회해서 roles 다시 가져오는 게 안전
+                    // refresh 토큰에 roles 안 넣었다면, DB 조회해서 roles 다시 가져오는 게 안전
                     .claim("roles", jwt.getClaim("roles"))
                     .build();
 
@@ -85,4 +85,31 @@ public class AuthController {
                 "roles", jwt.getClaim("roles")
         );
     }
+
+    @GetMapping("/logout")
+    public ResponseEntity<Void> logout(HttpServletResponse response) {
+        // ACCESS_TOKEN 만료
+        ResponseCookie accessCookie = ResponseCookie.from("ACCESS_TOKEN", "")
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("Strict")
+                .path("/")
+                .maxAge(0)  // 즉시 만료
+                .build();
+
+        // REFRESH_TOKEN 만료
+        ResponseCookie refreshCookie = ResponseCookie.from("REFRESH_TOKEN", "")
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("Strict")
+                .path("/auth/refresh")
+                .maxAge(0)  // 즉시 만료
+                .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, accessCookie.toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
+
+        return ResponseEntity.noContent().build(); // 204 No Content
+    }
+
 }

--- a/src/main/java/team/avgmax/rabbit/auth/controller/LoginController.java
+++ b/src/main/java/team/avgmax/rabbit/auth/controller/LoginController.java
@@ -2,17 +2,13 @@ package team.avgmax.rabbit.auth.controller;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 
 @Controller
 public class LoginController {
 
-    @GetMapping("/login/google")
-    public String loginWithGoogle() {
-        return "redirect:/oauth2/authorization/google";
-    }
-
-    @GetMapping("/login/naver")
-    public String loginWithNaver() {
-        return "redirect:/oauth2/authorization/naver";
+    @GetMapping("/login/{provider}")
+    public String loginWithProvider(@PathVariable String provider) {
+        return "redirect:/oauth2/authorization/" + provider;
     }
 }

--- a/src/main/java/team/avgmax/rabbit/auth/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/team/avgmax/rabbit/auth/oauth2/CustomOAuth2UserService.java
@@ -51,8 +51,9 @@ public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2Authentic
         Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
         Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
 
-        email = (String) kakaoAccount.get("email");
-        name = (String) profile.get("nickname");
+        email = registrationId + "_" + attributes.get("id") + "@avgmax.team";
+        name = profile.get("nickname").toString();
+
         providerId = String.valueOf(attributes.get("id"));
 
     } else {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -47,7 +47,7 @@ spring:
             client-authentication-method: client_secret_post
             authorization-grant-type: authorization_code
             redirect-uri: ${KAKAO_REDIRECT_URL}
-            scope: account_email, profile_nickname, profile_image
+            scope: profile_nickname
             client-name: Kakao
 
           github:


### PR DESCRIPTION
## 📌 작업 개요
- 개인 사용자 인가 시 URL 기반 RBAC 기능 수정 및 logout 추가

## ✅ 작업 상세
- ROLE_USER 권한 있는데, /auth/** 접근 안되던 문제 수정 (jwtAuthenticationConverter 추가)
  - 기본으로 하면 ROLE  기반 인증이 안된다고함
- jwt 가지고 로그아웃 엔드포인트 (/auth/logout) 접근 시 브라우저에서 토큰 만료

## 🎫 관련 이슈
- [RABBIT-18](https://dssw5.atlassian.net/browse/RABBIT-18)

## 🎬 참고 이미지
- /login/google
<img width="2487" height="291" alt="image" src="https://github.com/user-attachments/assets/b6ed07dd-c1ed-41d3-96a2-0440b3593ac7" />
- /auth/me
<img width="2487" height="281" alt="image" src="https://github.com/user-attachments/assets/01b67911-2f1d-4e25-a72d-e5d4871d2898" />
- /auth/logout
<img width="2487" height="308" alt="image" src="https://github.com/user-attachments/assets/c33d204b-a542-469a-ab82-6c29b265e53a" />


## 📎 기타
- 없음.