### PR TITLE
fix:[RABBIT-29] 개인 유저 엔드포인트 잘못 제거해서 다시 추가

### DIFF
--- a/src/main/java/team/avgmax/rabbit/user/service/PersonalUserService.java
+++ b/src/main/java/team/avgmax/rabbit/user/service/PersonalUserService.java
@@ -79,5 +79,9 @@ public class PersonalUserService {
     public OrdersResponse getOrdersById(String personalUserId) {
         return orderRepositoryCustom.findOrdersByUserId(personalUserId);
     }
-    
+
+    public PersonalUser findPersonalUserById(String userId) {
+        return personalUserRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserError.USER_NOT_FOUND));
+    }
 }


### PR DESCRIPTION
## 📌 작업 개요
- 개인 유저 컨트롤러에서 잘못 제거된 엔드포인트 다시 추가

## ✅ 작업 상세
- PersonalUserService.java에서 findPersonalUserById conflict 수정 과정에서 잘못 제거되어 다시 추가

## 🎫 관련 이슈
- [RABBIT-29](https://dssw5.atlassian.net/browse/RABBIT-29)

## 🎬 참고 이미지
- 빌드 성공 이미지
<img width="1911" height="590" alt="image" src="https://github.com/user-attachments/assets/04e3d461-5e4c-43c1-a6b8-bc4280c655a0" />

## 📎 기타
- 없음.