### PR TITLE
feat: [RABBIT-35] PersonalUser 수정 엔드포인트 작성 (PUT)

### DIFF
--- a/src/main/java/team/avgmax/rabbit/funding/exception/FundingError.java
+++ b/src/main/java/team/avgmax/rabbit/funding/exception/FundingError.java
@@ -19,7 +19,8 @@ public enum FundingError implements ErrorCode {
     BUNNY_TYPE_INVALID(HttpStatus.BAD_REQUEST, "지원하지 않는 버니 타입입니다. A, B, C 중 하나를 선택해주세요."),
     FUND_BUNNY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 펀드버니입니다."),
     BNY_NOT_POSITIVE(HttpStatus.BAD_REQUEST, "BNY는 양수여야 합니다."),
-    FUND_BNY_OVER_LIMIT(HttpStatus.BAD_REQUEST, "펀딩 가능한 BNY를 초과하는 요청입니다.");
+    FUND_BNY_OVER_LIMIT(HttpStatus.BAD_REQUEST, "펀딩 가능한 BNY를 초과하는 요청입니다."),
+    ALREADY_FUND_BUNNY_USER(HttpStatus.FORBIDDEN, "이미 심사 중인 유저입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/team/avgmax/rabbit/funding/repository/FundBunnyRepository.java
+++ b/src/main/java/team/avgmax/rabbit/funding/repository/FundBunnyRepository.java
@@ -4,8 +4,10 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import team.avgmax.rabbit.funding.entity.FundBunny;
+import team.avgmax.rabbit.user.entity.PersonalUser;
 
 public interface FundBunnyRepository extends JpaRepository<FundBunny, String>, FundBunnyRepositoryCustom {
+    boolean existsByUser(PersonalUser user);
     boolean existsByBunnyName(String bunnyName);
     Page<FundBunny> findAllByOrderByCreatedAtAsc(Pageable pageable);
     Page<FundBunny> findAllByOrderByCreatedAtDesc(Pageable pageable);

--- a/src/main/java/team/avgmax/rabbit/global/config/SecurityConfig.java
+++ b/src/main/java/team/avgmax/rabbit/global/config/SecurityConfig.java
@@ -57,8 +57,9 @@ public class SecurityConfig {
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/login/**", "/error", "/auth/dummy").permitAll()
                 .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
-                .requestMatchers(HttpMethod.POST, "/fund-bunnies").hasRole("BUNNY")
-                .requestMatchers("/user/**", "/auth/**", "/fund-bunnies/**").hasRole("USER")
+                .requestMatchers("/user/**", "/auth/**").hasRole("USER")
+                .requestMatchers(HttpMethod.POST, "/fund-bunnies").hasRole("USER")
+                .requestMatchers("/fund-bunnies/**").hasAnyRole("USER", "BUNNY")
                 .anyRequest().hasRole("USER")
             )
             .sessionManagement(session -> session

--- a/src/main/java/team/avgmax/rabbit/user/controller/PersonalUserController.java
+++ b/src/main/java/team/avgmax/rabbit/user/controller/PersonalUserController.java
@@ -6,10 +6,12 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import team.avgmax.rabbit.user.dto.request.UpdatePersonalUserRequest;
 import team.avgmax.rabbit.user.dto.response.CarrotsResponse;
 import team.avgmax.rabbit.user.dto.response.HoldBunniesResponse;
 import team.avgmax.rabbit.user.dto.response.OrdersResponse;
@@ -33,10 +35,10 @@ public class PersonalUserController {
     }
 
     @PutMapping("/me/info")
-    public String updateMyInfo(@AuthenticationPrincipal Jwt jwt) {
+    public ResponseEntity<PersonalUserResponse> updateMyInfo(@AuthenticationPrincipal Jwt jwt, @RequestBody UpdatePersonalUserRequest request) {
         String personalUserId = jwt.getSubject();
         log.info("내 정보 수정 : {}", personalUserId);
-        return "Update My Info";
+        return ResponseEntity.ok(personalUserService.updateUserById(personalUserId, request));
     }   
 
     @GetMapping("/me/carrots")

--- a/src/main/java/team/avgmax/rabbit/user/dto/request/CareerRequest.java
+++ b/src/main/java/team/avgmax/rabbit/user/dto/request/CareerRequest.java
@@ -1,0 +1,19 @@
+package team.avgmax.rabbit.user.dto.request;
+
+import java.time.LocalDate;
+
+import team.avgmax.rabbit.user.entity.enums.CareerStatus;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record CareerRequest(
+    String companyName,
+    CareerStatus status,
+    String position,
+    LocalDate startDate,
+    LocalDate endDate,
+    String certificateUrl
+) {
+}

--- a/src/main/java/team/avgmax/rabbit/user/dto/request/CertificationRequest.java
+++ b/src/main/java/team/avgmax/rabbit/user/dto/request/CertificationRequest.java
@@ -1,0 +1,15 @@
+package team.avgmax.rabbit.user.dto.request;
+
+import java.time.LocalDate;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record CertificationRequest(
+    String certificateUrl,
+    String name,
+    String ca,
+    LocalDate cdate
+) { 
+}

--- a/src/main/java/team/avgmax/rabbit/user/dto/request/EducationRequest.java
+++ b/src/main/java/team/avgmax/rabbit/user/dto/request/EducationRequest.java
@@ -1,0 +1,19 @@
+package team.avgmax.rabbit.user.dto.request;
+
+import java.time.LocalDate;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import team.avgmax.rabbit.user.entity.enums.EducationStatus;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record EducationRequest(
+    String schoolName,
+    EducationStatus status,
+    String major,
+    LocalDate startDate,
+    LocalDate endDate,
+    String certificateUrl
+) { 
+}

--- a/src/main/java/team/avgmax/rabbit/user/dto/request/SnsRequest.java
+++ b/src/main/java/team/avgmax/rabbit/user/dto/request/SnsRequest.java
@@ -1,0 +1,6 @@
+package team.avgmax.rabbit.user.dto.request;
+
+public record SnsRequest(
+    String url
+) {   
+}

--- a/src/main/java/team/avgmax/rabbit/user/dto/request/UpdatePersonalUserRequest.java
+++ b/src/main/java/team/avgmax/rabbit/user/dto/request/UpdatePersonalUserRequest.java
@@ -1,0 +1,25 @@
+package team.avgmax.rabbit.user.dto.request;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import team.avgmax.rabbit.user.entity.enums.Position;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record UpdatePersonalUserRequest(
+    String name,
+    LocalDate birthdate,
+    String image,
+    String resume,
+    String portfolio,
+    List<SnsRequest> link,
+    Position position,
+    List<EducationRequest> education,
+    List<CareerRequest> career,
+    List<CertificationRequest> certification,
+    List<String> skill
+) {
+}

--- a/src/main/java/team/avgmax/rabbit/user/dto/response/CareerResponse.java
+++ b/src/main/java/team/avgmax/rabbit/user/dto/response/CareerResponse.java
@@ -12,6 +12,7 @@ import team.avgmax.rabbit.user.entity.enums.CareerStatus;
 @Builder
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record CareerResponse(
+    String careerId,
     String companyName,
     CareerStatus status,
     String position,
@@ -21,6 +22,7 @@ public record CareerResponse(
 ) {
     public static CareerResponse from(Career career) {
         return CareerResponse.builder()
+                .careerId(career.getId())
                 .companyName(career.getCompanyName())
                 .status(career.getStatus())
                 .position(career.getPosition())

--- a/src/main/java/team/avgmax/rabbit/user/dto/response/CertificationResponse.java
+++ b/src/main/java/team/avgmax/rabbit/user/dto/response/CertificationResponse.java
@@ -11,6 +11,7 @@ import team.avgmax.rabbit.user.entity.Certification;
 @Builder
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record CertificationResponse(
+    String certificationId,
     String certificateUrl,
     String name,
     String ca,
@@ -18,6 +19,7 @@ public record CertificationResponse(
 ) {
     public static CertificationResponse from(Certification certification) {
         return CertificationResponse.builder()
+                .certificationId(certification.getId())
                 .certificateUrl(certification.getCertificateUrl())
                 .name(certification.getName())
                 .ca(certification.getCa())

--- a/src/main/java/team/avgmax/rabbit/user/dto/response/EducationResponse.java
+++ b/src/main/java/team/avgmax/rabbit/user/dto/response/EducationResponse.java
@@ -13,6 +13,7 @@ import team.avgmax.rabbit.user.entity.enums.EducationStatus;
 @Builder
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record EducationResponse(
+    String educationId,
     String schoolName,
     EducationStatus status,
     String major,
@@ -22,6 +23,7 @@ public record EducationResponse(
 ) {
     public static EducationResponse from(Education education) {
         return EducationResponse.builder()
+                .educationId(education.getId())
                 .schoolName(education.getSchoolName())
                 .status(education.getStatus())
                 .major(education.getMajor())

--- a/src/main/java/team/avgmax/rabbit/user/dto/response/PersonalUserResponse.java
+++ b/src/main/java/team/avgmax/rabbit/user/dto/response/PersonalUserResponse.java
@@ -16,6 +16,7 @@ public record PersonalUserResponse(
         LocalDate birthdate,
         String image,
         String resume,
+        String portfolio,
         List<SnsResponse> link,
         String position,
         List<EducationResponse> education,
@@ -29,6 +30,7 @@ public record PersonalUserResponse(
                 .birthdate(personalUser.getBirthdate())
                 .image(personalUser.getImage())
                 .resume(personalUser.getResume())
+                .portfolio(personalUser.getPortfolio())
                 .link(SnsResponse.from(personalUser.getSns()))
                 .position(personalUser.getPosition().name())
                 .education(EducationResponse.from(personalUser.getEducation()))

--- a/src/main/java/team/avgmax/rabbit/user/dto/response/SnsResponse.java
+++ b/src/main/java/team/avgmax/rabbit/user/dto/response/SnsResponse.java
@@ -10,12 +10,14 @@ import team.avgmax.rabbit.user.entity.Sns;
 @Builder
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record SnsResponse(
+    String snsId,
     String url,
     String type,
     String favicon
 ) {
     public static SnsResponse from(Sns sns) {
         return SnsResponse.builder()
+                .snsId(sns.getId())
                 .url(sns.getUrl())
                 .type(sns.getType().name())
                 .favicon(sns.getType().getFaviconUrl(sns.getUrl()))

--- a/src/main/java/team/avgmax/rabbit/user/entity/Career.java
+++ b/src/main/java/team/avgmax/rabbit/user/entity/Career.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 import team.avgmax.rabbit.global.util.UlidGenerator;
+import team.avgmax.rabbit.user.dto.request.CareerRequest;
 import team.avgmax.rabbit.user.entity.enums.CareerStatus;
 
 import team.avgmax.rabbit.global.entity.BaseTime;
@@ -34,6 +35,17 @@ public class Career extends BaseTime {
     private LocalDate endDate;
 
     private String certificateUrl;
-
+    
     private Integer priority;
+
+    public static Career create(CareerRequest request) {
+        return Career.builder()
+                .companyName(request.companyName())
+                .status(request.status())
+                .position(request.position())
+                .startDate(request.startDate())
+                .endDate(request.endDate())
+                .certificateUrl(request.certificateUrl())
+                .build();
+    }
 }

--- a/src/main/java/team/avgmax/rabbit/user/entity/Certification.java
+++ b/src/main/java/team/avgmax/rabbit/user/entity/Certification.java
@@ -5,6 +5,7 @@ import lombok.*;
 import lombok.experimental.SuperBuilder;
 import team.avgmax.rabbit.global.entity.BaseTime;
 import team.avgmax.rabbit.global.util.UlidGenerator;
+import team.avgmax.rabbit.user.dto.request.CertificationRequest;
 
 import java.time.LocalDate;
 
@@ -29,4 +30,13 @@ public class Certification extends BaseTime {
     private LocalDate cdate;
 
     private Integer priority;
+
+    public static Certification create(CertificationRequest request) {
+        return Certification.builder()
+                .certificateUrl(request.certificateUrl())
+                .name(request.name())
+                .ca(request.ca())
+                .cdate(request.cdate())
+                .build();
+    }
 }

--- a/src/main/java/team/avgmax/rabbit/user/entity/Education.java
+++ b/src/main/java/team/avgmax/rabbit/user/entity/Education.java
@@ -5,6 +5,7 @@ import lombok.*;
 import lombok.experimental.SuperBuilder;
 import team.avgmax.rabbit.global.entity.BaseTime;
 import team.avgmax.rabbit.global.util.UlidGenerator;
+import team.avgmax.rabbit.user.dto.request.EducationRequest;
 import team.avgmax.rabbit.user.entity.enums.EducationStatus;
 
 import java.time.LocalDate;
@@ -35,4 +36,15 @@ public class Education extends BaseTime {
     private String certificateUrl;
 
     private Integer priority;
+
+    public static Education create(EducationRequest request) {
+        return Education.builder()
+                .schoolName(request.schoolName())
+                .status(request.status())
+                .major(request.major())
+                .startDate(request.startDate())
+                .endDate(request.endDate())
+                .certificateUrl(request.certificateUrl())
+                .build();
+    }
 }

--- a/src/main/java/team/avgmax/rabbit/user/entity/PersonalUser.java
+++ b/src/main/java/team/avgmax/rabbit/user/entity/PersonalUser.java
@@ -16,6 +16,7 @@ import jakarta.persistence.OneToMany;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 import team.avgmax.rabbit.global.util.UlidGenerator;
+import team.avgmax.rabbit.user.dto.request.UpdatePersonalUserRequest;
 import team.avgmax.rabbit.user.entity.enums.Position;
 import team.avgmax.rabbit.user.exception.UserException;
 import team.avgmax.rabbit.user.exception.UserError;
@@ -89,5 +90,43 @@ public class PersonalUser extends User {
             throw new UserException(UserError.CARROT_NOT_ENOUGH);
         }
         this.carrot = this.carrot.subtract(carrot);
+    }
+
+    public void updatePersonalUser(UpdatePersonalUserRequest request) {
+        updateUser(request.name(), request.image());
+        this.birthdate = request.birthdate();
+        this.resume = request.resume();
+        this.portfolio = request.portfolio();
+        this.position = request.position();
+        
+        // SNS 업데이트
+        this.sns.clear();
+        this.sns.addAll(request.link().stream()
+            .map(Sns::create)
+            .toList());
+    
+        // Skill 업데이트
+        this.skill.clear();
+        this.skill.addAll(request.skill().stream()
+            .map(Skill::create)
+            .toList());
+    
+        // Certification 업데이트
+        this.certification.clear();
+        this.certification.addAll(request.certification().stream()
+            .map(Certification::create)
+            .toList());
+        
+        // Career 업데이트
+        this.career.clear();
+        this.career.addAll(request.career().stream()
+            .map(Career::create)
+            .toList());
+    
+        // Education 업데이트
+        this.education.clear();
+        this.education.addAll(request.education().stream()
+            .map(Education::create)
+            .toList());
     }
 }

--- a/src/main/java/team/avgmax/rabbit/user/entity/Skill.java
+++ b/src/main/java/team/avgmax/rabbit/user/entity/Skill.java
@@ -21,4 +21,10 @@ public class Skill extends BaseTime {
     private String skillName;
 
     private Integer priority;
+
+    public static Skill create(String skillName) {
+        return Skill.builder()
+                .skillName(skillName)
+                .build();
+    }
 }

--- a/src/main/java/team/avgmax/rabbit/user/entity/Sns.java
+++ b/src/main/java/team/avgmax/rabbit/user/entity/Sns.java
@@ -5,6 +5,7 @@ import lombok.*;
 import lombok.experimental.SuperBuilder;
 import team.avgmax.rabbit.global.entity.BaseTime;
 import team.avgmax.rabbit.global.util.UlidGenerator;
+import team.avgmax.rabbit.user.dto.request.SnsRequest;
 import team.avgmax.rabbit.user.entity.enums.LinkType;
 
 @Entity
@@ -25,4 +26,15 @@ public class Sns extends BaseTime {
     private LinkType type;
 
     private Integer priority;
+
+    public static Sns create(SnsRequest request) {
+        return Sns.builder()
+                .url(request.url())
+                .type(LinkType.fromUrl(request.url()))
+                .build();
+    }
+    
+    public void updateSns(SnsRequest request) {
+        if (url != null) this.url = request.url();
+    }
 }

--- a/src/main/java/team/avgmax/rabbit/user/entity/User.java
+++ b/src/main/java/team/avgmax/rabbit/user/entity/User.java
@@ -29,4 +29,10 @@ public abstract class User extends BaseTime {
     public void updateRoleToBunny() {
         this.role = Role.ROLE_BUNNY;
     }
+
+    // === 업데이트 메서드 ===
+    protected void updateUser(String name, String image) {
+        if (name != null) this.name = name;
+        if (image != null) this.image = image;
+    }
 }

--- a/src/main/java/team/avgmax/rabbit/user/service/PersonalUserService.java
+++ b/src/main/java/team/avgmax/rabbit/user/service/PersonalUserService.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import team.avgmax.rabbit.user.dto.request.UpdatePersonalUserRequest;
 import team.avgmax.rabbit.user.dto.response.CarrotsResponse;
 import team.avgmax.rabbit.user.dto.response.HoldBunniesResponse;
 import team.avgmax.rabbit.user.dto.response.OrdersResponse;
@@ -51,28 +52,40 @@ public class PersonalUserService {
         return user;
     }
 
+    @Transactional(readOnly = true)
     public PersonalUserResponse getUserById(String personalUserId) {
-        PersonalUser personalUser = personalUserRepository.findById(personalUserId)
-                .orElseThrow(() -> new UserException(UserError.USER_NOT_FOUND));
+        PersonalUser personalUser = findPersonalUserById(personalUserId);
 
         return PersonalUserResponse.from(personalUser);
     }
 
+    public PersonalUserResponse updateUserById(String personalUserId, UpdatePersonalUserRequest request) {
+        PersonalUser personalUser = findPersonalUserById(personalUserId);
+        
+        personalUser.updatePersonalUser(request);
+        PersonalUser savedUser = personalUserRepository.save(personalUser);
+
+        return PersonalUserResponse.from(savedUser);
+    }
+
+    @Transactional(readOnly = true)
     public CarrotsResponse getCarrotsById(String personalUserId) {
-        PersonalUser personalUser = personalUserRepository.findById(personalUserId)
-                .orElseThrow(() -> new UserException(UserError.USER_NOT_FOUND));
+        PersonalUser personalUser = findPersonalUserById(personalUserId);
         
         return CarrotsResponse.from(personalUser);
     }
 
+    @Transactional(readOnly = true)
     public HoldBunniesResponse getBunniesById(String personalUserId) {
         return holdBunnyRepositoryCustom.findHoldbunniesByUserId(personalUserId);
     }
 
+    @Transactional(readOnly = true)
     public OrdersResponse getOrdersById(String personalUserId) {
         return orderRepositoryCustom.findOrdersByUserId(personalUserId);
     }
 
+    @Transactional(readOnly = true)
     public PersonalUser findPersonalUserById(String userId) {
         return personalUserRepository.findById(userId)
                 .orElseThrow(() -> new UserException(UserError.USER_NOT_FOUND));


### PR DESCRIPTION
## 📌 작업 개요
- 나의 정보 수정 PUT API 구현

## ✅ 작업 상세
- 나의 정보 수정 API를 구현했습니다.
- 연관관계 데이터(Sns, Education, Career, Certification, Skill)는 요청 시 기존에 있던 데이터를 모두 delete하고, 새로운 데이터들로 insert 하도록 했습니다.
    - 요청이 많아지면 부하가 발생할 수 있지만, 코드가 간결하고 개발 비용이 적음
- /fund-bunnies API 인가 설정이 잘못되어 있어 수정했습니다.
- 조회용 서비스 메서드에서는 Transaction(readOnly=true) 설정 추가했습니다.

## 🎫 관련 이슈
- [RABBIT-35](https://dssw5.atlassian.net/browse/RABBIT-35)

## 🎬 참고 이미지
<img width="946" height="937" alt="스크린샷 2025-09-12 14 23 34" src="https://github.com/user-attachments/assets/c6e3a13a-939d-4e01-8717-66b15d9d581c" />

## 📎 기타
- 없음.