### PR TITLE
feat: [RABBIT-21] 펀드버니 유효기간 만료 처리 (redis)

### DIFF
--- a/src/main/java/team/avgmax/rabbit/funding/entity/FundBunny.java
+++ b/src/main/java/team/avgmax/rabbit/funding/entity/FundBunny.java
@@ -46,12 +46,12 @@ public class FundBunny extends BaseTime {
     @OneToMany(mappedBy = "fundBunny", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Funding> fundings;
 
-    public static FundBunny create(CreateFundBunnyRequest request, PersonalUser user) {
+    public static FundBunny create(CreateFundBunnyRequest request, PersonalUser user, long expiryMillis) {
         return FundBunny.builder()
                 .user(user)
                 .bunnyName(request.bunnyName())
                 .type(request.bunnyType())
-                .endAt(LocalDateTime.now().plusDays(3))
+                .endAt(LocalDateTime.now().plusDays(expiryMillis / (24 * 60 * 60 * 1000)))
                 .build();
     }
 

--- a/src/main/java/team/avgmax/rabbit/funding/service/FundBunnyExpirationListener.java
+++ b/src/main/java/team/avgmax/rabbit/funding/service/FundBunnyExpirationListener.java
@@ -1,0 +1,48 @@
+package team.avgmax.rabbit.funding.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.data.redis.listener.PatternTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.stereotype.Component;
+
+import jakarta.annotation.PostConstruct;
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class FundBunnyExpirationListener implements MessageListener {
+
+    private final RedisMessageListenerContainer redisMessageListenerContainer;
+    private final FundingService fundingService;
+
+    @PostConstruct
+    public void init() {
+        // Redis 키 만료 이벤트를 구독합니다
+        redisMessageListenerContainer.addMessageListener(this, new PatternTopic("__keyevent@0__:expired"));
+        log.info("FundBunny 만료 이벤트 리스너가 시작되었습니다.");
+    }
+
+    @Override
+    public void onMessage(@NonNull Message message, @Nullable byte[] pattern) {
+        String expiredKey = new String(message.getBody());
+        log.info("Redis 키가 만료되었습니다: {}", expiredKey);
+
+        // FundBunny 관련 키인지 확인
+        if (expiredKey.startsWith("fund_bunny:")) {
+            String fundBunnyId = expiredKey.replace("fund_bunny:", "");
+            log.info("FundBunny 만료 이벤트 감지: {}", fundBunnyId);
+            
+            try {
+                fundingService.processFundBunnyExpiration(fundBunnyId);
+                log.info("FundBunny 만료 처리 완료: {}", fundBunnyId);
+            } catch (Exception e) {
+                log.error("FundBunny 만료 처리 중 오류 발생: {}", fundBunnyId, e);
+            }
+        }
+    }
+}

--- a/src/main/java/team/avgmax/rabbit/global/util/RedisUtil.java
+++ b/src/main/java/team/avgmax/rabbit/global/util/RedisUtil.java
@@ -31,22 +31,4 @@ public class RedisUtil {
         redisTemplate.delete(key);
     }
 
-    /**
-     * FundBunny 만료 시간을 설정합니다.
-     * @param fundBunnyId FundBunny ID
-     * @param expirationTimeMillis 만료 시간 (밀리초)
-     */
-    public void setFundBunnyExpiration(String fundBunnyId, long expirationTimeMillis) {
-        String key = "fund_bunny:" + fundBunnyId;
-        redisTemplate.opsForValue().set(key, "expiration_marker", expirationTimeMillis, TimeUnit.MILLISECONDS);
-    }
-
-    /**
-     * FundBunny 만료 시간을 제거합니다.
-     * @param fundBunnyId FundBunny ID
-     */
-    public void removeFundBunnyExpiration(String fundBunnyId) {
-        String key = "fund_bunny:" + fundBunnyId;
-        redisTemplate.delete(key);
-    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -104,6 +104,10 @@ app:
     jwt:
       access-expiry: 900  # 15분 (60 * 15)
       refresh-expiry: 86400  # 24시간 (60 * 60 * 24)
+  redis:
+    fund-bunny:
+      expiry: 259200000 # 3일 = 3 * 24 * 60 * 60 * 1000 밀리초
+  
 
 server:
   port: 8080


### PR DESCRIPTION
## 📌 작업 개요
- Redis로 펀드버니 유효기간 만료 처리

## ✅ 작업 상세
- Redis에 fund_bunny에 id를 등록하고 ttl로 유효시간을 설정했습니다.
- 유효 기간 만료 시, FundBunny를 제거하고, 이와 연관된 Funding들에 대한 환불 처리를 진행합니다.
- FundBunny의 유효 기간(3일)을 application.yml에 설정 추가했습니다.

## 🎫 관련 이슈
- [RABBIT-21](https://dssw5.atlassian.net/browse/RABBIT-21)

## 🎬 참고 이미지
<img width="1298" height="35" alt="스크린샷 2025-09-13 20 46 49" src="https://github.com/user-attachments/assets/f4bf623c-ba6d-4618-9040-12a828f84a9a" />

## 📎 기타
- 서버의 레디스에서 애플리케이션에 만료 시간을 알릴 수 있도록 설정이 필요합니다.
``` bash
redis-cli -a 'password' config set notify-keyspace-events Ex
```