### PR TITLE
feat: [RABBIT-39] 거래 차트 조회 API 구현

### DIFF
--- a/src/main/java/team/avgmax/rabbit/bunny/controller/BunnyController.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/controller/BunnyController.java
@@ -8,9 +8,11 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import team.avgmax.rabbit.auth.oauth2.CustomOAuth2User;
+import team.avgmax.rabbit.bunny.dto.response.ChartResponse;
 import team.avgmax.rabbit.bunny.dto.response.FetchBunnyResponse;
 import team.avgmax.rabbit.bunny.dto.response.MyBunnyResponse;
 import team.avgmax.rabbit.bunny.entity.enums.BunnyFilter;
+import team.avgmax.rabbit.bunny.entity.enums.ChartInterval;
 import team.avgmax.rabbit.bunny.service.BunnyService;
 
 import java.util.List;
@@ -46,5 +48,13 @@ public class BunnyController {
         log.info("GET 마이 버니 조회: {}", customOAuth2User.getName());
 
         return ResponseEntity.ok(bunnyService.getMyBunny(customOAuth2User));
+    }
+
+    // 거래 차트 조회
+    @GetMapping("/{bunnyName}/chart")
+    public ResponseEntity<ChartResponse> getChart(@PathVariable String bunnyName, @RequestParam(defaultValue = "DAILY") ChartInterval interval) {
+        log.info("GET 거래 차트 조회: {}, interval: {}", bunnyName, interval);
+
+        return ResponseEntity.ok(bunnyService.getChart(bunnyName, interval));
     }
 }

--- a/src/main/java/team/avgmax/rabbit/bunny/dto/response/ChartDataPoint.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/dto/response/ChartDataPoint.java
@@ -1,0 +1,38 @@
+package team.avgmax.rabbit.bunny.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import team.avgmax.rabbit.bunny.entity.BunnyHistory;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class ChartDataPoint {
+
+    private LocalDate date;
+    private BigDecimal highPrice;
+    private BigDecimal lowPrice;
+    private BigDecimal closingPrice;
+    private BigDecimal buyQuantity;
+    private BigDecimal sellQuantity;
+    private BigDecimal tradeVolume; // tradeQuantity
+
+    public static ChartDataPoint from(BunnyHistory bunnyHistory) {
+        return ChartDataPoint.builder()
+                .date(bunnyHistory.getDate())
+                .highPrice(bunnyHistory.getHighPrice())
+                .lowPrice(bunnyHistory.getLowPrice())
+                .closingPrice(bunnyHistory.getClosingPrice())
+                .buyQuantity(bunnyHistory.getBuyQuantity())
+                .sellQuantity(bunnyHistory.getSellQuantity())
+                .tradeVolume(bunnyHistory.getTradeQuantity())
+                .build();
+    }
+}

--- a/src/main/java/team/avgmax/rabbit/bunny/dto/response/ChartResponse.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/dto/response/ChartResponse.java
@@ -1,0 +1,35 @@
+package team.avgmax.rabbit.bunny.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Builder;
+import lombok.Getter;
+import team.avgmax.rabbit.bunny.entity.Bunny;
+import team.avgmax.rabbit.bunny.entity.enums.ChartInterval;
+
+import java.util.List;
+
+@Getter
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class ChartResponse {
+
+    private String bunnyName; // 혹시 몰라서 추가 해놓은 필드, 삭제 가능
+    private ChartInterval interval; // DAILY, WEEKLY, MONTHLY
+    private List<ChartDataPoint> chartDataList;
+
+    public static ChartResponse from(List<ChartDataPoint> chartDataList, Bunny bunny, ChartInterval interval) {
+        return ChartResponse.builder()
+                .bunnyName(bunny.getBunnyName())
+                .interval(interval)
+                .chartDataList(chartDataList)
+                .build();
+    }
+    public static ChartResponse from(List<ChartDataPoint> chartDataList, String bunnyName, ChartInterval interval) {
+        return ChartResponse.builder()
+                .bunnyName(bunnyName)
+                .interval(interval)
+                .chartDataList(chartDataList)
+                .build();
+    }
+}

--- a/src/main/java/team/avgmax/rabbit/bunny/dto/response/MyBunnyResponse.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/dto/response/MyBunnyResponse.java
@@ -1,5 +1,7 @@
 package team.avgmax.rabbit.bunny.dto.response;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.Getter;
 import team.avgmax.rabbit.bunny.dto.data.ComparisonData;
@@ -18,6 +20,7 @@ import java.util.List;
 
 @Getter
 @Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class MyBunnyResponse {
 
     // 요구사항 1: 코인명, 코인유형, 직군, 이름, 오늘날짜, 배지

--- a/src/main/java/team/avgmax/rabbit/bunny/entity/enums/BadgeImg.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/entity/enums/BadgeImg.java
@@ -3,5 +3,5 @@ package team.avgmax.rabbit.bunny.entity.enums;
 public enum BadgeImg {
     KAKAO,
     NAVER,
-    SINHAN
+    SHINHAN
 }

--- a/src/main/java/team/avgmax/rabbit/bunny/entity/enums/ChartInterval.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/entity/enums/ChartInterval.java
@@ -1,0 +1,7 @@
+package team.avgmax.rabbit.bunny.entity.enums;
+
+public enum ChartInterval {
+    DAILY,
+    WEEKLY,
+    MONTHLY
+}

--- a/src/main/java/team/avgmax/rabbit/bunny/repository/BunnyHistoryRepository.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/repository/BunnyHistoryRepository.java
@@ -2,10 +2,11 @@ package team.avgmax.rabbit.bunny.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import team.avgmax.rabbit.bunny.entity.BunnyHistory;
+import team.avgmax.rabbit.bunny.repository.custom.BunnyHistoryRepositoryCustom;
 
 import java.util.List;
 
-public interface BunnyHistoryRepository extends JpaRepository<BunnyHistory, String> {
+public interface BunnyHistoryRepository extends JpaRepository<BunnyHistory, String>, BunnyHistoryRepositoryCustom {
 
     List<BunnyHistory> findAllByBunnyIdOrderByDateAsc(String bunnyId);
 }

--- a/src/main/java/team/avgmax/rabbit/bunny/repository/custom/BunnyHistoryRepositoryCustom.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/repository/custom/BunnyHistoryRepositoryCustom.java
@@ -1,0 +1,11 @@
+package team.avgmax.rabbit.bunny.repository.custom;
+
+import team.avgmax.rabbit.bunny.dto.response.ChartDataPoint;
+import team.avgmax.rabbit.bunny.entity.enums.ChartInterval;
+
+import java.util.List;
+
+public interface BunnyHistoryRepositoryCustom {
+
+    List<ChartDataPoint> findChartData(String bunnyId, ChartInterval interval);
+}

--- a/src/main/java/team/avgmax/rabbit/bunny/repository/custom/BunnyHistoryRepositoryCustomImpl.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/repository/custom/BunnyHistoryRepositoryCustomImpl.java
@@ -1,0 +1,150 @@
+package team.avgmax.rabbit.bunny.repository.custom;
+
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.core.types.dsl.NumberTemplate;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import team.avgmax.rabbit.bunny.dto.response.ChartDataPoint;
+import team.avgmax.rabbit.bunny.entity.QBunnyHistory;
+import team.avgmax.rabbit.bunny.entity.enums.ChartInterval;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.List;
+
+import static com.querydsl.core.types.Projections.constructor;
+import static team.avgmax.rabbit.bunny.entity.QBunnyHistory.bunnyHistory;
+
+@RequiredArgsConstructor
+public class BunnyHistoryRepositoryCustomImpl implements BunnyHistoryRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<ChartDataPoint> findChartData(String bunnyId, ChartInterval interval) {
+        if (bunnyId == null) return Collections.emptyList();
+
+        return switch (interval) {
+            case DAILY -> fetchDaily(bunnyId);
+            case WEEKLY -> fetchWeekly(bunnyId);
+            case MONTHLY -> fetchMonthly(bunnyId);
+        };
+    }
+
+    private List<ChartDataPoint> fetchDaily(String bunnyId) {
+        return queryFactory
+                .select(constructor(ChartDataPoint.class,
+                        bunnyHistory.date,
+                        bunnyHistory.highPrice,
+                        bunnyHistory.lowPrice,
+                        bunnyHistory.closingPrice,
+                        bunnyHistory.buyQuantity,
+                        bunnyHistory.sellQuantity,
+                        bunnyHistory.tradeQuantity
+                ))
+                .from(bunnyHistory)
+                .where(bunnyHistory.bunnyId.eq(bunnyId))
+                .orderBy(bunnyHistory.date.asc())
+                .fetch();
+    }
+
+    private List<ChartDataPoint> fetchWeekly(String bunnyId) {
+        NumberTemplate<Integer> weekKey =
+                Expressions.numberTemplate(Integer.class, "YEARWEEK({0}, 3)", bunnyHistory.date);
+
+        // 합계의 null 보정 (COALESCE(SUM(...), 0))
+        NumberExpression<BigDecimal> buySum =
+                Expressions.numberTemplate(BigDecimal.class, "COALESCE(SUM({0}), 0)", bunnyHistory.buyQuantity);
+        NumberExpression<BigDecimal> sellSum =
+                Expressions.numberTemplate(BigDecimal.class, "COALESCE(SUM({0}), 0)", bunnyHistory.sellQuantity);
+        NumberExpression<BigDecimal> tradeSum =
+                Expressions.numberTemplate(BigDecimal.class, "COALESCE(SUM({0}), 0)", bunnyHistory.tradeQuantity);
+
+        QBunnyHistory bhMax = new QBunnyHistory("bhMax");
+        QBunnyHistory bhLast = new QBunnyHistory("bhLast");
+
+        return queryFactory
+                .select(constructor(ChartDataPoint.class,
+                        // 대표 날짜: 그 주의 마지막 날짜
+                        bunnyHistory.date.max(),
+                        // 주간 가격 요약
+                        bunnyHistory.highPrice.max(),
+                        bunnyHistory.lowPrice.min(),
+                        // 그 주의 마지막 날짜의 종가
+                        JPAExpressions.select(bhLast.closingPrice)
+                                .from(bhLast)
+                                .where(
+                                        bhLast.bunnyId.eq(bunnyId),
+                                        Expressions.numberTemplate(Integer.class, "YEARWEEK({0}, 3)", bhLast.date).eq(weekKey),
+                                        bhLast.date.eq(
+                                                JPAExpressions.select(bhMax.date.max())
+                                                        .from(bhMax)
+                                                        .where(
+                                                                bhMax.bunnyId.eq(bunnyId),
+                                                                Expressions.numberTemplate(Integer.class, "YEARWEEK({0}, 3)", bhMax.date).eq(weekKey)
+                                                        )
+                                        )
+                                ),
+                        // 주간 합계
+                        buySum,
+                        sellSum,
+                        tradeSum
+                ))
+                .from(bunnyHistory)
+                .where(bunnyHistory.bunnyId.eq(bunnyId))
+                .groupBy(weekKey)
+                .orderBy(weekKey.asc())
+                .fetch();
+    }
+
+    private List<ChartDataPoint> fetchMonthly(String bunnyId) {
+        NumberTemplate<Integer> monthKey =
+                Expressions.numberTemplate(Integer.class, "EXTRACT(YEAR_MONTH FROM {0})", bunnyHistory.date);
+
+        // 합계의 null 보정 (COALESCE(SUM(...), 0))
+        NumberExpression<BigDecimal> buySum =
+                Expressions.numberTemplate(BigDecimal.class, "COALESCE(SUM({0}), 0)", bunnyHistory.buyQuantity);
+        NumberExpression<BigDecimal> sellSum =
+                Expressions.numberTemplate(BigDecimal.class, "COALESCE(SUM({0}), 0)", bunnyHistory.sellQuantity);
+        NumberExpression<BigDecimal> tradeSum =
+                Expressions.numberTemplate(BigDecimal.class, "COALESCE(SUM({0}), 0)", bunnyHistory.tradeQuantity);
+
+        QBunnyHistory bhMax = new QBunnyHistory("mhMax");
+        QBunnyHistory bhLast = new QBunnyHistory("mhLast");
+
+        return queryFactory
+                .select(constructor(ChartDataPoint.class,
+                        // 대표 날짜: 그 달의 마지막 날짜
+                        bunnyHistory.date.max(),
+                        // 월간 가격 요약
+                        bunnyHistory.highPrice.max(),
+                        bunnyHistory.lowPrice.min(),
+                        // 그 달의 마지막 날짜의 종가
+                        JPAExpressions.select(bhLast.closingPrice)
+                                .from(bhLast)
+                                .where(
+                                        bhLast.bunnyId.eq(bunnyId),
+                                        Expressions.numberTemplate(Integer.class, "EXTRACT(YEAR_MONTH FROM {0})", bhLast.date).eq(monthKey),
+                                        bhLast.date.eq(
+                                                JPAExpressions.select(bhMax.date.max())
+                                                        .from(bhMax)
+                                                        .where(
+                                                                bhMax.bunnyId.eq(bunnyId),
+                                                                Expressions.numberTemplate(Integer.class, "EXTRACT(YEAR_MONTH FROM {0})", bhMax.date).eq(monthKey)
+                                                        )
+                                        )
+                                ),
+                        // 월간 합계
+                        buySum,
+                        sellSum,
+                        tradeSum
+                ))
+                .from(bunnyHistory)
+                .where(bunnyHistory.bunnyId.eq(bunnyId))
+                .groupBy(monthKey)
+                .orderBy(monthKey.asc())
+                .fetch();
+    }
+}


### PR DESCRIPTION
## 📌 작업 개요
- 거래 차트 조회 API 구현

## ✅ 작업 상세
- 거래 차트 조회 관련 비즈니스 로직 구현
- 일간/주간/월간 집계 처리를 프론트가 아닌 백엔드에서 하도록 구현

## 🎫 관련 이슈
- [RABBIT-39](https://dssw5.atlassian.net/browse/RABBIT-39)

## 🎬 참고 이미지
- (테스트 성공한 이미지 첨부)

## 📎 기타
- 없음