### PR TITLE
feat: [RABBIT-49] 기본 정보 조회 API 구현

### DIFF
--- a/src/main/java/team/avgmax/rabbit/bunny/repository/BunnyRepository.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/repository/BunnyRepository.java
@@ -21,6 +21,6 @@ public interface BunnyRepository extends JpaRepository<Bunny, String>, BunnyRepo
     // 버니 상세 조회에 사용, Optional<>로 NullPointException 방지
     Optional<Bunny> findByBunnyName(String bunnyName);
 
-    Optional<Bunny> findByUserId(String bunnyId);
+    Optional<Bunny> findByUserId(String userId);
 
 }

--- a/src/main/java/team/avgmax/rabbit/funding/service/FundingService.java
+++ b/src/main/java/team/avgmax/rabbit/funding/service/FundingService.java
@@ -50,7 +50,7 @@ public class FundingService {
     private final RedisUtil redisUtil;
 
     @Value("${app.redis.fund-bunny.expiry}")
-    private final Long fundBunnyExpiry;
+    private Long fundBunnyExpiry;
 
     @Transactional(readOnly = true)
     public FundBunnyCountResponse getFundBunnyCount() {

--- a/src/main/java/team/avgmax/rabbit/user/controller/PersonalUserController.java
+++ b/src/main/java/team/avgmax/rabbit/user/controller/PersonalUserController.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import team.avgmax.rabbit.user.dto.request.UpdatePersonalUserRequest;
 import team.avgmax.rabbit.user.dto.response.CarrotsResponse;
+import team.avgmax.rabbit.user.dto.response.FetchUserResponse;
 import team.avgmax.rabbit.user.dto.response.HoldBunniesResponse;
 import team.avgmax.rabbit.user.dto.response.OrdersResponse;
 import team.avgmax.rabbit.user.dto.response.PersonalUserResponse;
@@ -25,7 +26,15 @@ import team.avgmax.rabbit.user.service.PersonalUserService;
 public class PersonalUserController {
 
     private final PersonalUserService personalUserService;
-    
+
+    @GetMapping("/me")
+    public ResponseEntity<FetchUserResponse> fetchPersonalUser(@AuthenticationPrincipal Jwt jwt) {
+        String personalUserId = jwt.getSubject();
+        log.info("기본 정보 조회: {}", personalUserId);
+        
+        return ResponseEntity.ok(personalUserService.fetchUserById(personalUserId));
+    }
+
     @GetMapping("/me/info")
     public ResponseEntity<PersonalUserResponse> getMyInfo(@AuthenticationPrincipal Jwt jwt) {
         String personalUserId = jwt.getSubject();

--- a/src/main/java/team/avgmax/rabbit/user/dto/response/FetchUserResponse.java
+++ b/src/main/java/team/avgmax/rabbit/user/dto/response/FetchUserResponse.java
@@ -1,0 +1,29 @@
+package team.avgmax.rabbit.user.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import lombok.Builder;
+import team.avgmax.rabbit.user.entity.PersonalUser;
+
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record FetchUserResponse (
+    String userId,
+    String name,
+    String image,
+    String role,
+    String carrot,
+    String myBunnyId
+) {
+    public static FetchUserResponse from(PersonalUser personalUser, String myBunnyId) {
+        return FetchUserResponse.builder()
+                .userId(personalUser.getId())
+                .name(personalUser.getName())
+                .image(personalUser.getImage())
+                .role(personalUser.getRole().name())
+                .carrot(personalUser.getCarrot().toString())
+                .myBunnyId(myBunnyId)
+                .build();
+    }
+}

--- a/src/main/java/team/avgmax/rabbit/user/service/PersonalUserService.java
+++ b/src/main/java/team/avgmax/rabbit/user/service/PersonalUserService.java
@@ -7,6 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import team.avgmax.rabbit.user.dto.request.UpdatePersonalUserRequest;
 import team.avgmax.rabbit.user.dto.response.CarrotsResponse;
+import team.avgmax.rabbit.user.dto.response.FetchUserResponse;
 import team.avgmax.rabbit.user.dto.response.HoldBunniesResponse;
 import team.avgmax.rabbit.user.dto.response.OrdersResponse;
 import team.avgmax.rabbit.user.dto.response.PersonalUserResponse;
@@ -16,6 +17,8 @@ import team.avgmax.rabbit.user.exception.UserError;
 import team.avgmax.rabbit.user.exception.UserException;
 import team.avgmax.rabbit.user.entity.UserProvider;
 import team.avgmax.rabbit.user.entity.enums.ProviderType;
+import team.avgmax.rabbit.bunny.entity.Bunny;
+import team.avgmax.rabbit.bunny.repository.BunnyRepository;
 import team.avgmax.rabbit.user.repository.PersonalUserRepository;
 import team.avgmax.rabbit.user.repository.custom.HoldBunnyRepositoryCustomImpl;
 import team.avgmax.rabbit.user.repository.custom.OrderRepositoryCustomImpl;
@@ -28,6 +31,7 @@ public class PersonalUserService {
     private final PersonalUserRepository personalUserRepository;
     private final OrderRepositoryCustomImpl orderRepositoryCustom;
     private final HoldBunnyRepositoryCustomImpl holdBunnyRepositoryCustom;
+    private final BunnyRepository bunnyRepository;
 
     public PersonalUser findOrCreateUser(String email, String name, String registrationId, String providerId) {
         PersonalUser user = personalUserRepository.findByEmail(email)
@@ -50,6 +54,16 @@ public class PersonalUserService {
         }
 
         return user;
+    }
+
+    @Transactional(readOnly = true)
+    public FetchUserResponse fetchUserById(String personalUserId) {
+        PersonalUser personalUser = findPersonalUserById(personalUserId);
+        String myBunnyId = bunnyRepository.findByUserId(personalUserId)
+            .map(Bunny::getId)
+            .orElse(null);
+
+        return FetchUserResponse.from(personalUser, myBunnyId);
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## 📌 작업 개요
- 기본 정보 조회 API 구현

## ✅ 작업 상세
- 프론트엔드를 위한 사용자의 기본 정보 상태 관리 용도로 사용할 수 있는 기본 정보 조회 API를 구현했습니다.

## 🎫 관련 이슈
- [RABBIT-49](https://dssw5.atlassian.net/browse/RABBIT-49)

## 🎬 참고 이미지
<img width="958" height="371" alt="image" src="https://github.com/user-attachments/assets/b88a5f2f-581b-4257-a741-221b29497235" />

## 📎 기타
- 없음.