### PR TITLE
feat: [RABBIT-50] User, Auth 도메인 Swagger 설정

### DIFF
--- a/src/main/java/team/avgmax/rabbit/auth/controller/AuthApiDocs.java
+++ b/src/main/java/team/avgmax/rabbit/auth/controller/AuthApiDocs.java
@@ -1,0 +1,115 @@
+package team.avgmax.rabbit.auth.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.jwt.Jwt;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.util.Map;
+
+@Tag(name = "Auth", description = "인증 API")
+public interface AuthApiDocs {
+
+    @Operation(
+        summary = "리프레시 토큰 발급",
+        description = "액세스 토큰이 만료되어 새로운 리프레시 토큰을 발급받습니다."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "리프레시 토큰 발급 성공",
+            content = @Content(
+                mediaType = "application/json",
+                examples = @ExampleObject(
+                    value = """
+                    {
+                        "message": "new access token issued"
+                    }
+                    """
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "401",
+            description = "인증 실패",
+            content = @Content(
+                mediaType = "application/json",
+                examples = @ExampleObject(
+                    value = """
+                    {
+                        "error": "No refresh token"
+                    }
+                    """
+                )
+            )
+        )
+    })
+    ResponseEntity<?> refreshToken(HttpServletRequest request, HttpServletResponse response);
+
+    @Operation(
+        summary = "현재 사용자 정보 조회",
+        description = "현재 로그인한 사용자의 정보를 조회합니다."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "사용자 정보 조회 성공",
+            content = @Content(
+                mediaType = "application/json",
+                examples = @ExampleObject(
+                    value = """
+                    {
+                        "sub": "01HZXUSER00000000000000001",
+                        "roles": ["ROLE_USER"]
+                    }
+                    """
+                )
+            )
+        )
+    })
+    Map<String, Object> user(Jwt jwt);
+
+    @Operation(
+        summary = "로그아웃",
+        description = "사용자를 로그아웃하고 모든 토큰을 만료시킵니다."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "204",
+            description = "로그아웃 성공"
+        )
+    })
+    ResponseEntity<Void> logout(HttpServletResponse response);
+
+    @Operation(
+        summary = "더미 토큰 발급",
+        description = "개발 및 테스트를 위한 더미 액세스 토큰을 발급합니다."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "더미 토큰 발급 성공",
+            content = @Content(
+                mediaType = "application/json",
+                examples = @ExampleObject(
+                    value = """
+                    {
+                        "message": "더미 액세스 토큰 발급: {accessToken}"
+                    }
+                    """
+                )
+            )
+        )
+    })
+    ResponseEntity<?> dummy(
+        HttpServletResponse response,
+        @Parameter(description = "더미 사용자 ID", required = true) String personalUserId
+    );
+}

--- a/src/main/java/team/avgmax/rabbit/auth/controller/AuthController.java
+++ b/src/main/java/team/avgmax/rabbit/auth/controller/AuthController.java
@@ -21,7 +21,7 @@ import java.util.Map;
 @RestController
 @RequestMapping("/auth")
 @RequiredArgsConstructor
-public class AuthController {
+public class AuthController implements AuthApiDocs {
 
     private final JwtDecoder jwtDecoder;
     private final JwtEncoder jwtEncoder;
@@ -141,6 +141,6 @@ public class AuthController {
 
         response.setHeader(HttpHeaders.SET_COOKIE, accessCookie.toString());
 
-        return ResponseEntity.ok(Map.of("message", "더미 액세스 토큰 발급"));
+        return ResponseEntity.ok(Map.of("message", "더미 액세스 토큰 발급: " + accessToken));
     }
 }

--- a/src/main/java/team/avgmax/rabbit/bunny/repository/BunnyRepository.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/repository/BunnyRepository.java
@@ -21,6 +21,6 @@ public interface BunnyRepository extends JpaRepository<Bunny, String>, BunnyRepo
     // 버니 상세 조회에 사용, Optional<>로 NullPointException 방지
     Optional<Bunny> findByBunnyName(String bunnyName);
 
-    Optional<Bunny> findByUserId(String bunnyId);
+    Optional<Bunny> findByUserId(String userId);
 
 }

--- a/src/main/java/team/avgmax/rabbit/funding/service/FundingService.java
+++ b/src/main/java/team/avgmax/rabbit/funding/service/FundingService.java
@@ -50,7 +50,7 @@ public class FundingService {
     private final RedisUtil redisUtil;
 
     @Value("${app.redis.fund-bunny.expiry}")
-    private final Long fundBunnyExpiry;
+    private Long fundBunnyExpiry;
 
     @Transactional(readOnly = true)
     public FundBunnyCountResponse getFundBunnyCount() {

--- a/src/main/java/team/avgmax/rabbit/user/controller/PersonalUserApiDocs.java
+++ b/src/main/java/team/avgmax/rabbit/user/controller/PersonalUserApiDocs.java
@@ -1,0 +1,386 @@
+package team.avgmax.rabbit.user.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.jwt.Jwt;
+import team.avgmax.rabbit.user.dto.request.UpdatePersonalUserRequest;
+import team.avgmax.rabbit.user.dto.response.CarrotsResponse;
+import team.avgmax.rabbit.user.dto.response.FetchUserResponse;
+import team.avgmax.rabbit.user.dto.response.HoldBunniesResponse;
+import team.avgmax.rabbit.user.dto.response.OrdersResponse;
+import team.avgmax.rabbit.user.dto.response.PersonalUserResponse;
+
+@Tag(name = "PersonalUser", description = "개인 사용자 API")
+public interface PersonalUserApiDocs {
+
+    @Operation(
+        summary = "기본 정보 조회 (fetch)",
+        description = "사용자 정보 fetch를 위해 현재 로그인한 사용자의 기본 정보를 조회합니다."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "기본 정보 조회 성공",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = FetchUserResponse.class),
+                examples = @ExampleObject(
+                    value = """
+                    {
+                        "user_id": "01HZXUSER00000000000000001",
+                        "name": "사용자_01",
+                        "image": "https://picsum.photos/200",
+                        "role": "ROLE_USER",
+                        "carrot": "1000000",
+                        "my_bunny_id": "01HZXBUNNY00000000000000001"
+                    }
+                    """
+                )
+            )
+        )
+    })
+    ResponseEntity<FetchUserResponse> fetchPersonalUser(
+        @Parameter(description = "JWT 토큰", hidden = true) Jwt jwt
+    );
+
+    @Operation(
+        summary = "나의 정보 조회",
+        description = "현재 로그인한 사용자의 상세 정보를 조회합니다."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "나의 정보 조회 성공",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = PersonalUserResponse.class),
+                examples = @ExampleObject(
+                    value = """
+                    {
+                        "user_id": "01HZXUSER00000000000000001",
+                        "name": "사용자_01",
+                        "birthdate": "1990-01-25",
+                        "image": "https://picsum.photos/200",
+                        "email": "user01@test.com",
+                        "resume": "https://example.com/resume.pdf",
+                        "portfolio": "https://example.com/portfolio.pdf",
+                        "link": [
+                            {
+                                "sns_id": "01HZXSNS00000000000000001",
+                                "url": "https://github.com/jjweidon",
+                                "type": "GITHUB",
+                                "favicon": "https://github.com/favicon"
+                            },
+                            {
+                                "sns_id": "01HZXSNS00000000000000002",
+                                "url": "https:/instagram.com/jwoong_8",
+                                "type": "INSTAGRAM",
+                                "favicon": "https:/instagram.com/favicon",
+                            },
+                            {
+                                "sns_id": "01HZXSNS00000000000000003",
+                                "url": "https:/linkedin.com/jwoong_8",
+                                "type": "LINKEDIN",
+                                "favicon": "https:/linkedin.com/favicon",
+                            },
+                        ],
+                        "position": "BACKEND",
+                        "education": [
+                            {   
+                                "education_id": "01HZXEDUCATION00000000000000001",
+                                "school_name": "신한고등학교",
+                                "status": "GRADUATED",
+                                "major": "자연계",
+                                "start_date": "2020-09-01",
+                                "end_date": "2023-06-30",
+                                "certificate_url": "https://example.com/certificate.pdf"
+                            },
+                            {
+                                "education_id": "01HZXEDUCATION00000000000000002",
+                                "school_name": "신한대학교",
+                                "status": "ENROLLED",
+                                "major": "컴퓨터공학과",
+                                "start_date": "2020-09-01",
+                                "end_date": "2023-06-30",
+                                "certificate_url": "https://example.com/certificate.pdf"
+                            }
+                        ],
+                        "career": [
+                            {
+                                "career_id": "01HZXCAREER00000000000000001",
+                                "company_name": "신한은행",
+                                "status": "UNEMPLOYED",
+                                "position": "마케터", 
+                                "start_date": "2023-09-01",
+                                "end_date": "2025-12-31",
+                                "certificate_url": "https://example.com/certificate.pdf"
+                            },
+                            {
+                                "career_id": "01HZXCAREER00000000000000002",
+                                "company_name": "신한DS",
+                                "status": "EMPLOYED",
+                                "position": "백엔드 엔지니어",
+                                "start_date": "2023-09-01",
+                                "end_date": "2025-12-31",
+                                "certificate_url": "https://example.com/certificate.pdf"
+                            }
+                        ],
+                        "certification": [
+                            {
+                                "certification_id": "01HZXCERTIFICATION00000000000000001",
+                                "certificate_url": "https://fileurl.com",
+                                "name": "정보처리기사",
+                                "ca": "에이비지맥스",
+                                "cdate": "2015-09-01"
+                            },
+                            {
+                                "certification_id": "01HZXCERTIFICATION00000000000000002",
+                                "certificate_url": "https://fileurl.com",
+                                "name": "SQLD",
+                                "ca": "에이비지맥스",
+                                "cdate": "2015-09-02"
+                            },
+                        ],
+                        "skill": [
+                            "Java",
+                            "Javascript",
+                            "SpringBoot",
+                            "React"
+                        ]
+                    }
+                    """
+                )
+            )
+        )
+    })
+    ResponseEntity<PersonalUserResponse> getMyInfo(
+        @Parameter(description = "JWT 토큰", hidden = true) Jwt jwt
+    );
+
+    @Operation(
+        summary = "나의 정보 수정",
+        description = "현재 로그인한 사용자의 정보를 수정합니다."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "나의 정보 수정 성공",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = PersonalUserResponse.class),
+                examples = @ExampleObject(
+                    value = """
+                    {
+                        "user_id": "01HZXUSER00000000000000001",
+                        "name": "사용자_01",
+                        "birthdate": "1990-01-25",
+                        "image": "https://picsum.photos/200",
+                        "email": "user01@test.com",
+                        "resume": "https://example.com/resume.pdf",
+                        "portfolio": "https://example.com/portfolio.pdf",
+                        "link": [
+                            {
+                                "sns_id": "01HZXSNS00000000000000001",
+                                "link": "https://github.com/jjweidon",
+                                "type": "GITHUB",
+                                "favicon": "https://github.com/favicon"
+                            },
+                            {
+                                "sns_id": "01HZXSNS00000000000000002",
+                                "link": "https:/instagram.com/jwoong_8",
+                                "type": "INSTAGRAM",
+                                "favicon": "https:/instagram.com/favicon",
+                            },
+                            {
+                                "sns_id": "01HZXSNS00000000000000003",
+                                "link": "https:/linkedin.com/jwoong_8",
+                                "type": "LINKEDIN",
+                                "favicon": "https:/linkedin.com/favicon",
+                            },
+                        ],
+                        "position": "BACKEND",
+                        "education": [
+                            {   
+                                "education_id": "01HZXEDUCATION00000000000000001",
+                                "school_name": "신한고등학교",
+                                "status": "GRADUATED",
+                                "major": "자연계",
+                                "start_date": "2020-09-01",
+                                "end_date": "2023-06-30",
+                                "certificate_url": "https://example.com/certificate.pdf"
+                            },
+                            {
+                                "education_id": "01HZXEDUCATION00000000000000002",
+                                "school_name": "신한대학교",
+                                "status": "ENROLLED",
+                                "major": "컴퓨터공학과",
+                                "start_date": "2020-09-01",
+                                "end_date": "2023-06-30",
+                                "certificate_url": "https://example.com/certificate.pdf"
+                            }
+                        ],
+                        "career": [
+                            {
+                                "career_id": "01HZXCAREER00000000000000001",
+                                "company_name": "신한은행",
+                                "status": "UNEMPLOYED",
+                                "position": "마케터", 
+                                "start_date": "2023-09-01",
+                                "end_date": "2025-12-31",
+                                "certificate_url": "https://example.com/certificate.pdf"
+                            },
+                            {
+                                "career_id": "01HZXCAREER00000000000000002",
+                                "company_name": "신한DS",
+                                "status": "EMPLOYED",
+                                "position": "백엔드 엔지니어",
+                                "start_date": "2023-09-01",
+                                "end_date": "2025-12-31",
+                                "certificate_url": "https://example.com/certificate.pdf"
+                            }
+                        ],
+                        "certification": [
+                            {
+                                "certification_id": "01HZXCERTIFICATION00000000000000001",
+                                "certificate_url": "https://fileurl.com",
+                                "name": "정보처리기사",
+                                "ca": "에이비지맥스",
+                                "cdate": "2015-09-01"
+                            },
+                            {
+                                "certification_id": "01HZXCERTIFICATION00000000000000002",
+                                "certificate_url": "https://fileurl.com",
+                                "name": "SQLD",
+                                "ca": "에이비지맥스",
+                                "cdate": "2015-09-02"
+                            },
+                        ],
+                        "skill": [
+                            "Java",
+                            "Javascript",
+                            "SpringBoot",
+                            "React"
+                        ]
+                    }
+                    """
+                )
+            )
+        )
+    })
+    ResponseEntity<PersonalUserResponse> updateMyInfo(
+        @Parameter(description = "JWT 토큰", hidden = true) Jwt jwt,
+        @Parameter(description = "사용자 정보 수정 요청", required = true) UpdatePersonalUserRequest request
+    );
+
+    @Operation(
+        summary = "보유 캐럿 조회",
+        description = "현재 로그인한 사용자가 보유한 캐럿 정보를 조회합니다."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "보유 캐럿 조회 성공",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = CarrotsResponse.class),
+                examples = @ExampleObject(
+                    value = """
+                    {
+                        "carrots": 1000000
+                    }
+                    """
+                )
+            )
+        )
+    })
+    ResponseEntity<CarrotsResponse> getMyCarrots(
+        @Parameter(description = "JWT 토큰", hidden = true) Jwt jwt
+    );
+
+    @Operation(
+        summary = "보유 버니 조회",
+        description = "현재 로그인한 사용자가 보유한 버니 정보를 조회합니다."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "보유 버니 조회 성공",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = HoldBunniesResponse.class),
+                examples = @ExampleObject(
+                    value = """
+                    {
+                        "hold_bunnies": [
+                            {
+                                "bunny_id": "01HZXBUNNY00000000000000001",
+                                "bunny_name": "bunny-001",
+                                "hold_quantity": 100,
+                                "total_buy_amount": 100000
+                            },
+                            {
+                                "bunny_id": "01HZXBUNNY00000000000000002",
+                                "bunny_name": "bunny-002",
+                                "hold_quantity": 50,
+                                "total_buy_amount": 100000
+                            }
+                        ]
+                    }
+                    """
+                )
+            )
+        )
+    })
+    ResponseEntity<HoldBunniesResponse> getMyHoldBunnies(
+        @Parameter(description = "JWT 토큰", hidden = true) Jwt jwt
+    );
+
+    @Operation(
+        summary = "미체결 주문 목록 조회",
+        description = "현재 로그인한 사용자의 미체결 주문 내역을 조회합니다."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "미체결 주문 목록 조회 성공",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = OrdersResponse.class),
+                examples = @ExampleObject(
+                    value = """
+                    {
+                        "orders": [
+                            {
+                                "order_id": "01HZXORDER00000000000000001",
+                                "bunny_name": "bunny-001",
+                                "bunny_id": "01HZXBUNNY00000000000000001",
+                                "quantity": 100,
+                                "unit_price": 1000,
+                                "order_type": "BUY"
+                            },
+                            {
+                                "order_id": "01HZXORDER00000000000000002",
+                                "bunny_name": "bunny-002",
+                                "bunny_id": "01HZXBUNNY00000000000000002",
+                                "quantity": 50,
+                                "unit_price": 2000,
+                                "order_type": "SELL"
+                            }
+                        ]
+                    }
+                    """
+                )
+            )
+        )
+    })
+    ResponseEntity<OrdersResponse> getMyOrders(
+        @Parameter(description = "JWT 토큰", hidden = true) Jwt jwt
+    );
+}

--- a/src/main/java/team/avgmax/rabbit/user/controller/PersonalUserController.java
+++ b/src/main/java/team/avgmax/rabbit/user/controller/PersonalUserController.java
@@ -23,7 +23,7 @@ import team.avgmax.rabbit.user.service.PersonalUserService;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/personal")
-public class PersonalUserController {
+public class PersonalUserController implements PersonalUserApiDocs {
 
     private final PersonalUserService personalUserService;
 
@@ -38,7 +38,7 @@ public class PersonalUserController {
     @GetMapping("/me/info")
     public ResponseEntity<PersonalUserResponse> getMyInfo(@AuthenticationPrincipal Jwt jwt) {
         String personalUserId = jwt.getSubject();
-        log.info("내 정보 조회: {}", personalUserId);
+        log.info("나의 정보 조회: {}", personalUserId);
         
         return ResponseEntity.ok(personalUserService.getUserById(personalUserId));
     }
@@ -46,14 +46,14 @@ public class PersonalUserController {
     @PutMapping("/me/info")
     public ResponseEntity<PersonalUserResponse> updateMyInfo(@AuthenticationPrincipal Jwt jwt, @RequestBody UpdatePersonalUserRequest request) {
         String personalUserId = jwt.getSubject();
-        log.info("내 정보 수정 : {}", personalUserId);
+        log.info("나의 정보 수정 : {}", personalUserId);
         return ResponseEntity.ok(personalUserService.updateUserById(personalUserId, request));
     }   
 
     @GetMapping("/me/carrots")
     public ResponseEntity<CarrotsResponse> getMyCarrots(@AuthenticationPrincipal Jwt jwt) {
         String personalUserId = jwt.getSubject();
-        log.info("내 보유 캐럿 조회: {}", personalUserId);
+        log.info("보유 캐럿 조회: {}", personalUserId);
 
         return ResponseEntity.ok(personalUserService.getCarrotsById(personalUserId));
     }   
@@ -61,7 +61,7 @@ public class PersonalUserController {
     @GetMapping("/me/hold-bunnies")
     public ResponseEntity<HoldBunniesResponse> getMyHoldBunnies(@AuthenticationPrincipal Jwt jwt) {
         String personalUserId = jwt.getSubject();
-        log.info("내 보유 버니 조회: {}", personalUserId);
+        log.info("보유 버니 조회: {}", personalUserId);
 
         return ResponseEntity.ok(personalUserService.getBunniesById(personalUserId));
     }
@@ -69,7 +69,7 @@ public class PersonalUserController {
     @GetMapping("/me/orders")
     public ResponseEntity<OrdersResponse> getMyOrders(@AuthenticationPrincipal Jwt jwt) {
         String personalUserId = jwt.getSubject();
-        log.info("내 주문 조회: {}", personalUserId);  
+        log.info("미체결 주문 목록 조회: {}", personalUserId);  
 
         return ResponseEntity.ok(personalUserService.getOrdersById(personalUserId));
     }

--- a/src/main/java/team/avgmax/rabbit/user/controller/PersonalUserController.java
+++ b/src/main/java/team/avgmax/rabbit/user/controller/PersonalUserController.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import team.avgmax.rabbit.user.dto.request.UpdatePersonalUserRequest;
 import team.avgmax.rabbit.user.dto.response.CarrotsResponse;
+import team.avgmax.rabbit.user.dto.response.FetchUserResponse;
 import team.avgmax.rabbit.user.dto.response.HoldBunniesResponse;
 import team.avgmax.rabbit.user.dto.response.OrdersResponse;
 import team.avgmax.rabbit.user.dto.response.PersonalUserResponse;
@@ -25,7 +26,15 @@ import team.avgmax.rabbit.user.service.PersonalUserService;
 public class PersonalUserController {
 
     private final PersonalUserService personalUserService;
-    
+
+    @GetMapping("/me")
+    public ResponseEntity<FetchUserResponse> fetchPersonalUser(@AuthenticationPrincipal Jwt jwt) {
+        String personalUserId = jwt.getSubject();
+        log.info("기본 정보 조회: {}", personalUserId);
+        
+        return ResponseEntity.ok(personalUserService.fetchUserById(personalUserId));
+    }
+
     @GetMapping("/me/info")
     public ResponseEntity<PersonalUserResponse> getMyInfo(@AuthenticationPrincipal Jwt jwt) {
         String personalUserId = jwt.getSubject();

--- a/src/main/java/team/avgmax/rabbit/user/dto/request/UpdatePersonalUserRequest.java
+++ b/src/main/java/team/avgmax/rabbit/user/dto/request/UpdatePersonalUserRequest.java
@@ -13,6 +13,7 @@ public record UpdatePersonalUserRequest(
     String name,
     LocalDate birthdate,
     String image,
+    String email,
     String resume,
     String portfolio,
     List<SnsRequest> link,

--- a/src/main/java/team/avgmax/rabbit/user/dto/response/FetchUserResponse.java
+++ b/src/main/java/team/avgmax/rabbit/user/dto/response/FetchUserResponse.java
@@ -1,0 +1,29 @@
+package team.avgmax.rabbit.user.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import lombok.Builder;
+import team.avgmax.rabbit.user.entity.PersonalUser;
+
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record FetchUserResponse (
+    String userId,
+    String name,
+    String image,
+    String role,
+    String carrot,
+    String myBunnyId
+) {
+    public static FetchUserResponse from(PersonalUser personalUser, String myBunnyId) {
+        return FetchUserResponse.builder()
+                .userId(personalUser.getId())
+                .name(personalUser.getName())
+                .image(personalUser.getImage())
+                .role(personalUser.getRole().name())
+                .carrot(personalUser.getCarrot().toString())
+                .myBunnyId(myBunnyId)
+                .build();
+    }
+}

--- a/src/main/java/team/avgmax/rabbit/user/dto/response/PersonalUserResponse.java
+++ b/src/main/java/team/avgmax/rabbit/user/dto/response/PersonalUserResponse.java
@@ -12,9 +12,11 @@ import team.avgmax.rabbit.user.entity.Skill;
 @Builder
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record PersonalUserResponse(
+        String userId,
         String name,
         LocalDate birthdate,
         String image,
+        String email,
         String resume,
         String portfolio,
         List<SnsResponse> link,
@@ -26,9 +28,11 @@ public record PersonalUserResponse(
 ) {
     public static PersonalUserResponse from(PersonalUser personalUser) {
         return PersonalUserResponse.builder()
+                .userId(personalUser.getId())
                 .name(personalUser.getName())
                 .birthdate(personalUser.getBirthdate())
                 .image(personalUser.getImage())
+                .email(personalUser.getEmail())
                 .resume(personalUser.getResume())
                 .portfolio(personalUser.getPortfolio())
                 .link(SnsResponse.from(personalUser.getSns()))

--- a/src/main/java/team/avgmax/rabbit/user/entity/PersonalUser.java
+++ b/src/main/java/team/avgmax/rabbit/user/entity/PersonalUser.java
@@ -93,7 +93,7 @@ public class PersonalUser extends User {
     }
 
     public void updatePersonalUser(UpdatePersonalUserRequest request) {
-        updateUser(request.name(), request.image());
+        updateUser(request.name(), request.image(), request.email());
         this.birthdate = request.birthdate();
         this.resume = request.resume();
         this.portfolio = request.portfolio();

--- a/src/main/java/team/avgmax/rabbit/user/entity/User.java
+++ b/src/main/java/team/avgmax/rabbit/user/entity/User.java
@@ -31,8 +31,9 @@ public abstract class User extends BaseTime {
     }
 
     // === 업데이트 메서드 ===
-    protected void updateUser(String name, String image) {
+    protected void updateUser(String name, String image, String email) {
         if (name != null) this.name = name;
         if (image != null) this.image = image;
+        if (email != null) this.email = email;
     }
 }

--- a/src/main/java/team/avgmax/rabbit/user/service/PersonalUserService.java
+++ b/src/main/java/team/avgmax/rabbit/user/service/PersonalUserService.java
@@ -7,6 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import team.avgmax.rabbit.user.dto.request.UpdatePersonalUserRequest;
 import team.avgmax.rabbit.user.dto.response.CarrotsResponse;
+import team.avgmax.rabbit.user.dto.response.FetchUserResponse;
 import team.avgmax.rabbit.user.dto.response.HoldBunniesResponse;
 import team.avgmax.rabbit.user.dto.response.OrdersResponse;
 import team.avgmax.rabbit.user.dto.response.PersonalUserResponse;
@@ -16,6 +17,8 @@ import team.avgmax.rabbit.user.exception.UserError;
 import team.avgmax.rabbit.user.exception.UserException;
 import team.avgmax.rabbit.user.entity.UserProvider;
 import team.avgmax.rabbit.user.entity.enums.ProviderType;
+import team.avgmax.rabbit.bunny.entity.Bunny;
+import team.avgmax.rabbit.bunny.repository.BunnyRepository;
 import team.avgmax.rabbit.user.repository.PersonalUserRepository;
 import team.avgmax.rabbit.user.repository.custom.HoldBunnyRepositoryCustomImpl;
 import team.avgmax.rabbit.user.repository.custom.OrderRepositoryCustomImpl;
@@ -28,6 +31,7 @@ public class PersonalUserService {
     private final PersonalUserRepository personalUserRepository;
     private final OrderRepositoryCustomImpl orderRepositoryCustom;
     private final HoldBunnyRepositoryCustomImpl holdBunnyRepositoryCustom;
+    private final BunnyRepository bunnyRepository;
 
     public PersonalUser findOrCreateUser(String email, String name, String registrationId, String providerId) {
         PersonalUser user = personalUserRepository.findByEmail(email)
@@ -50,6 +54,16 @@ public class PersonalUserService {
         }
 
         return user;
+    }
+
+    @Transactional(readOnly = true)
+    public FetchUserResponse fetchUserById(String personalUserId) {
+        PersonalUser personalUser = findPersonalUserById(personalUserId);
+        String myBunnyId = bunnyRepository.findByUserId(personalUserId)
+            .map(Bunny::getId)
+            .orElse(null);
+
+        return FetchUserResponse.from(personalUser, myBunnyId);
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## 📌 작업 개요
- User, Auth 도메인 Swagger 설정

## ✅ 작업 상세
- User, Auth 도메인 API에 대해 프론트엔드 개발자를 위한 Swagger 설명을 추가했습니다.

## 🎫 관련 이슈
- [RABBIT-50](https://dssw5.atlassian.net/browse/RABBIT-50)

## 🎬 참고 이미지
<img width="626" height="792" alt="스크린샷 2025-09-15 10 36 49" src="https://github.com/user-attachments/assets/03904bdc-a0eb-4014-815d-5bc7ce672803" />

## 📎 기타
- 없음.