### PR TITLE
feat: [RABBIT-40] 거래 주문 요청 API 구현

### DIFF
--- a/src/main/java/team/avgmax/rabbit/bunny/controller/BunnyController.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/controller/BunnyController.java
@@ -1,5 +1,7 @@
 package team.avgmax.rabbit.bunny.controller;
 
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -8,19 +10,23 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import team.avgmax.rabbit.auth.oauth2.CustomOAuth2User;
+import team.avgmax.rabbit.bunny.dto.request.OrderRequest;
 import team.avgmax.rabbit.bunny.dto.response.ChartResponse;
 import team.avgmax.rabbit.bunny.dto.response.FetchBunnyResponse;
 import team.avgmax.rabbit.bunny.dto.response.MyBunnyResponse;
 import team.avgmax.rabbit.bunny.entity.enums.BunnyFilter;
 import team.avgmax.rabbit.bunny.entity.enums.ChartInterval;
 import team.avgmax.rabbit.bunny.service.BunnyService;
+import team.avgmax.rabbit.user.dto.response.OrderResponse;
+import team.avgmax.rabbit.user.entity.PersonalUser;
 
+import java.net.URI;
 import java.util.List;
 
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/bunnies")
+@RequestMapping(value = "/bunnies", produces = "application/json")
 public class BunnyController {
 
     private final BunnyService bunnyService;
@@ -44,10 +50,10 @@ public class BunnyController {
 
     // 마이 버니 조회
     @GetMapping("/me")
-    public ResponseEntity<MyBunnyResponse> getMyBunny(@AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
-        log.info("GET 마이 버니 조회: {}", customOAuth2User.getName());
+    public ResponseEntity<MyBunnyResponse> getMyBunny(@AuthenticationPrincipal CustomOAuth2User user) {
+        log.info("GET 마이 버니 조회: {}", user.getName());
 
-        return ResponseEntity.ok(bunnyService.getMyBunny(customOAuth2User));
+        return ResponseEntity.ok(bunnyService.getMyBunny(user));
     }
 
     // 거래 차트 조회
@@ -56,5 +62,22 @@ public class BunnyController {
         log.info("GET 거래 차트 조회: {}, interval: {}", bunnyName, interval);
 
         return ResponseEntity.ok(bunnyService.getChart(bunnyName, interval));
+    }
+
+    // 거래 주문 요청
+    @PostMapping(value = "/{bunnyName}/orders", consumes = "application/json")
+    public ResponseEntity<OrderResponse> createOrder(
+            @PathVariable String bunnyName,
+            @Valid @RequestBody OrderRequest request,
+            @AuthenticationPrincipal CustomOAuth2User user
+    ) {
+        log.info("POST 거래 주문 요청: user={}, bunny={}", user.getName(), bunnyName);
+
+        PersonalUser personalUser = user.getPersonalUser();
+        OrderResponse response = bunnyService.createOrder(bunnyName, request, personalUser);
+        // 차후에 절대경로를 추가해주면 좀 더 RESTful 해진다.
+        URI location = URI.create("/bunnies/" + bunnyName + "/orders/" + response.orderId());
+
+        return ResponseEntity.created(location).body(response);
     }
 }

--- a/src/main/java/team/avgmax/rabbit/bunny/dto/request/OrderRequest.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/dto/request/OrderRequest.java
@@ -1,0 +1,31 @@
+package team.avgmax.rabbit.bunny.dto.request;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import team.avgmax.rabbit.bunny.entity.Bunny;
+import team.avgmax.rabbit.bunny.entity.Order;
+import team.avgmax.rabbit.bunny.entity.enums.OrderType;
+import team.avgmax.rabbit.user.entity.PersonalUser;
+
+import java.math.BigDecimal;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record OrderRequest(
+        @NotNull @Positive BigDecimal quantity,
+        @NotNull @Positive BigDecimal unitPrice,
+        @NotNull OrderType orderType
+) {
+    public Order toEntity(PersonalUser user, Bunny bunny) {
+        if (user == null || bunny == null) throw new IllegalArgumentException("user / bunny 는 필수 입니다..");
+
+        return Order.builder()
+                .user(user)
+                .bunny(bunny)
+                .quantity(quantity)
+                .unitPrice(unitPrice)
+                .orderType(orderType)
+                .build();
+    }
+}

--- a/src/main/java/team/avgmax/rabbit/bunny/repository/OrderRepository.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/repository/OrderRepository.java
@@ -1,0 +1,7 @@
+package team.avgmax.rabbit.bunny.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import team.avgmax.rabbit.bunny.entity.Order;
+
+public interface OrderRepository extends JpaRepository<Order,String> {
+}

--- a/src/main/java/team/avgmax/rabbit/bunny/service/BunnyService.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/service/BunnyService.java
@@ -11,6 +11,7 @@ import team.avgmax.rabbit.bunny.dto.data.ComparisonData;
 import team.avgmax.rabbit.bunny.dto.data.DailyPriceData;
 import team.avgmax.rabbit.bunny.dto.data.MyBunnyByDevTypeData;
 import team.avgmax.rabbit.bunny.dto.data.MyBunnyByHolderData;
+import team.avgmax.rabbit.bunny.dto.request.OrderRequest;
 import team.avgmax.rabbit.bunny.dto.response.ChartDataPoint;
 import team.avgmax.rabbit.bunny.dto.response.ChartResponse;
 import team.avgmax.rabbit.bunny.dto.response.FetchBunnyResponse;
@@ -18,6 +19,7 @@ import team.avgmax.rabbit.bunny.dto.response.MyBunnyResponse;
 import team.avgmax.rabbit.bunny.entity.Badge;
 import team.avgmax.rabbit.bunny.entity.Bunny;
 import team.avgmax.rabbit.bunny.entity.BunnyHistory;
+import team.avgmax.rabbit.bunny.entity.Order;
 import team.avgmax.rabbit.bunny.entity.enums.BunnyFilter;
 import team.avgmax.rabbit.bunny.entity.enums.BunnyType;
 import team.avgmax.rabbit.bunny.entity.enums.ChartInterval;
@@ -27,6 +29,8 @@ import team.avgmax.rabbit.bunny.exception.BunnyException;
 import team.avgmax.rabbit.bunny.repository.BadgeRepository;
 import team.avgmax.rabbit.bunny.repository.BunnyHistoryRepository;
 import team.avgmax.rabbit.bunny.repository.BunnyRepository;
+import team.avgmax.rabbit.bunny.repository.OrderRepository;
+import team.avgmax.rabbit.user.dto.response.OrderResponse;
 import team.avgmax.rabbit.user.dto.response.SpecResponse;
 import team.avgmax.rabbit.user.entity.PersonalUser;
 import team.avgmax.rabbit.user.repository.HoldBunnyRepository;
@@ -47,6 +51,7 @@ public class BunnyService {
     private final BadgeRepository badgeRepository;
     private final BunnyHistoryRepository bunnyHistoryRepository;
     private final HoldBunnyRepository holdBunnyRepository;
+    private final OrderRepository orderRepository;
 
 
     // 버니 목록 조회
@@ -154,6 +159,19 @@ public class BunnyService {
                         .orElseGet(Collections::emptyList);
 
         return ChartResponse.from(chartData, bunny.getBunnyName(), interval);
+    }
+
+    // 거래 주문 요청
+    @Transactional(readOnly = true)
+    public OrderResponse createOrder(String bunnyName, OrderRequest request, PersonalUser personalUser) {
+        Bunny bunny = bunnyRepository.findByBunnyName(bunnyName)
+                .orElseThrow(() -> new BunnyException(BunnyError.BUNNY_NOT_FOUND));
+
+        Order order = request.toEntity(personalUser, bunny);
+
+        orderRepository.save(order);
+
+        return OrderResponse.from(order);
     }
 
     private List<DailyPriceData> getPriceHistory(String bunnyId) {

--- a/src/main/java/team/avgmax/rabbit/user/dto/response/OrderResponse.java
+++ b/src/main/java/team/avgmax/rabbit/user/dto/response/OrderResponse.java
@@ -1,15 +1,34 @@
 package team.avgmax.rabbit.user.dto.response;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
+import team.avgmax.rabbit.bunny.entity.Order;
+import team.avgmax.rabbit.bunny.entity.enums.OrderType;
 
 @Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record OrderResponse(
-    String orderId,
-    String bunnyName,
-    String bunnyId,
-    BigDecimal quantity,
-    BigDecimal unitPrice,
-    String orderType
-) {}
+        String orderId,
+        String bunnyName,
+        String bunnyId,
+        BigDecimal quantity,
+        BigDecimal unitPrice,
+        OrderType orderType,
+        LocalDateTime createdAt
+) {
+    public static OrderResponse from(Order order) {
+        return OrderResponse.builder()
+                .orderId(order.getId())
+                .bunnyName(order.getBunny().getBunnyName())
+                .bunnyId(order.getBunny().getId())
+                .quantity(order.getQuantity())
+                .unitPrice(order.getUnitPrice())
+                .orderType(order.getOrderType())
+                .createdAt(order.getCreatedAt())
+                .build();
+    }
+}


### PR DESCRIPTION
## 📌 작업 개요
- 거래 주문 요청 API 구현

## ✅ 작업 상세
- 거래 주문 요청에 관련된 비즈니스 로직 구현
- @RequestMapping(value = "/bunnies", produces = "application/json")으로 API 통신 시 오로지 JSON 형태로만 전달 됨을 명시함

## 🎫 관련 이슈
- [RABBIT-40](https://dssw5.atlassian.net/browse/RABBIT-40)

## 🎬 참고 이미지
- (테스트 성공한 이미지 첨부)

## 📎 기타
- OrderResponse가 이미 user에 존재해서 import로 사용
- OrderResponse 필드 변경
