### PR TITLE
feat:[RABBIT-37] openai api 관련 엔드포인트, 서비스 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,8 @@ configurations {
 
 repositories {
 	mavenCentral()
+	maven { url 'https://repo.spring.io/milestone' }
+	maven { url 'https://repo.spring.io/snapshot' }
 }
 
 dependencies {
@@ -60,6 +62,12 @@ dependencies {
 
 	// Redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	// Spring AI OpenAI
+	implementation platform("org.springframework.ai:spring-ai-bom:1.0.0-SNAPSHOT")
+	implementation 'org.springframework.ai:spring-ai-openai'
+	implementation 'org.springframework.ai:spring-ai-starter-model-openai'
+	implementation 'org.springframework.ai:spring-ai-advisors-vector-store'
 }
 
 // QueryDSL 설정

--- a/docker-compose.db.yml
+++ b/docker-compose.db.yml
@@ -1,0 +1,22 @@
+version: "3.9"
+
+services:
+  mariadb:
+    image: mariadb:10.6
+    container_name: mariadb
+    restart: always
+    environment:
+      MARIADB_ROOT_PASSWORD: 1234
+      MARIADB_DATABASE: rabbit
+      MARIADB_USER: rabbit
+      MARIADB_PASSWORD: 1234
+      TZ: Asia/Seoul
+    ports:
+      - "3306:3306"
+  redis:
+    image: redis:7.2
+    container_name: redis
+    restart: always
+    ports:
+      - "6379:6379"
+    command: ["redis-server", "--appendonly", "yes"]

--- a/src/main/java/team/avgmax/rabbit/ai/controller/ChatModelApiDocs.java
+++ b/src/main/java/team/avgmax/rabbit/ai/controller/ChatModelApiDocs.java
@@ -1,0 +1,71 @@
+package team.avgmax.rabbit.ai.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import team.avgmax.rabbit.ai.dto.response.ScoreResponse;
+import team.avgmax.rabbit.user.dto.request.UpdatePersonalUserRequest;
+import team.avgmax.rabbit.user.dto.response.*;
+
+@Tag(name = "AI", description = "OpenAI chat API")
+public interface ChatModelApiDocs {
+
+    @Operation(
+            summary = "질문",
+            description = "원하는 질문의 응답을 바로 받아볼 수 있는 엔드포인트"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "gpt 질의 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = "\"AI가 생성한 응답 텍스트 예시\""
+                            )
+                    )
+            )
+    })
+    ResponseEntity<String> ask(
+            @Parameter(description = "JWT 토큰", hidden = true) Jwt jwt,
+            @Parameter(description = "사용자가 입력한 질문") @RequestParam String answer
+    );
+
+    @Operation(
+        summary = "나의 점수 조회",
+        description = "현재 로그인한 사용자의 AI 판단 결과를 조회합니다."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "나의 정보 조회 성공",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ScoreResponse.class),
+                examples = @ExampleObject(
+                    value = """
+                    {
+                        "growth":70,
+                        "stability":80,
+                        "value":75,
+                        "popularity":65,
+                        "balance":60
+                    }
+                    """
+                )
+            )
+        )
+    })
+    ResponseEntity<ScoreResponse> score(
+        @Parameter(description = "JWT 토큰", hidden = true) Jwt jwt
+    );
+}

--- a/src/main/java/team/avgmax/rabbit/ai/controller/ChatModelController.java
+++ b/src/main/java/team/avgmax/rabbit/ai/controller/ChatModelController.java
@@ -1,0 +1,39 @@
+package team.avgmax.rabbit.ai.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import team.avgmax.rabbit.ai.dto.response.ScoreResponse;
+import team.avgmax.rabbit.ai.service.ChatModelService;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/ai")
+public class ChatModelController implements ChatModelApiDocs {
+
+    private final ChatModelService chatModelService;
+
+    @GetMapping("/ask")
+    public ResponseEntity<String> ask(@AuthenticationPrincipal Jwt jwt, @RequestParam String answer) {
+        String userId = jwt.getSubject();
+        log.info("GET /ai/ask: userId={}", userId);
+        return ResponseEntity.ok(chatModelService.ask(answer));
+    }
+
+    @GetMapping("/score")
+    public ResponseEntity<ScoreResponse> score(@AuthenticationPrincipal Jwt jwt) {
+        String personalUserId = jwt.getSubject();
+        log.info("GET /ai/score: userId={}", personalUserId);
+
+        return ResponseEntity.ok(chatModelService.score(personalUserId));
+    }
+}

--- a/src/main/java/team/avgmax/rabbit/ai/dto/response/ScoreResponse.java
+++ b/src/main/java/team/avgmax/rabbit/ai/dto/response/ScoreResponse.java
@@ -1,0 +1,16 @@
+package team.avgmax.rabbit.ai.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Builder;
+
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record ScoreResponse (
+        int growth,
+        int stability,
+        int value,
+        int popularity,
+        int balance
+) {
+}

--- a/src/main/java/team/avgmax/rabbit/ai/service/ChatModelService.java
+++ b/src/main/java/team/avgmax/rabbit/ai/service/ChatModelService.java
@@ -1,0 +1,94 @@
+package team.avgmax.rabbit.ai.service;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.converter.BeanOutputConverter;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.avgmax.rabbit.ai.dto.response.ScoreResponse;
+import team.avgmax.rabbit.user.entity.PersonalUser;
+import team.avgmax.rabbit.user.entity.Skill;
+import team.avgmax.rabbit.user.service.PersonalUserService;
+
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ChatModelService {
+
+    private final ChatModel chatModel;
+    private final PersonalUserService personalUserService;
+
+    public String ask(String q) {
+        UserMessage userMessage = new UserMessage(q);
+        Prompt prompt = new Prompt(userMessage);
+        ChatResponse response = chatModel.call(prompt);
+
+        return response.getResult().getOutput().getText();
+    }
+
+    public ScoreResponse score(String personalUserId) {
+        PersonalUser personalUser = personalUserService.findPersonalUserById(personalUserId);
+
+        BeanOutputConverter<ScoreResponse> responseConverter =
+                new BeanOutputConverter<>(ScoreResponse.class);
+        String responseSchema = responseConverter.getJsonSchema();
+
+        SystemMessage systemMessage = new SystemMessage(
+                "질문 내용에 있는 대상의 가치를 5가지 항목으로 평가하고 각각 0에서 100 사이의 점수로 점수를 부여해줘. \n\n"
+                        + "아래 JSON 스키마를 준수해서 반드시 JSON으로 반환해야 함.\n\n"
+                        + responseSchema
+        );
+
+        // Education 리스트 → 문자열
+        String educationStr = personalUser.getEducation().stream()
+                .map(e -> String.format("%s %s (%s ~ %s)",
+                        e.getSchoolName(),
+                        e.getMajor(),
+                        e.getStartDate(),
+                        e.getEndDate() != null ? e.getEndDate() : "재학 중"))
+                .collect(Collectors.joining("; "));
+
+        // Career 리스트 → 문자열
+        String careerStr = personalUser.getCareer().stream()
+                .map(c -> String.format("%s - %s (%s ~ %s)",
+                        c.getCompanyName(),
+                        c.getPosition(),
+                        c.getStartDate(),
+                        c.getEndDate() != null ? c.getEndDate() : "재직 중"))
+                .collect(Collectors.joining("; "));
+
+        // Skill 리스트 → 문자열
+        String skillsStr = personalUser.getSkill().stream()
+                .map(Skill::getSkillName)
+                .collect(Collectors.joining(", "));
+
+        // JSON 생성
+        String userJson = """
+        {
+          "education": "%s",
+          "portfolio": "%s",
+          "career": "%s",
+          "skills": "%s"
+        }
+        """.formatted(
+                educationStr,
+                personalUser.getPortfolio(),
+                careerStr,
+                skillsStr
+            );
+
+        // 5. AI 호출
+        UserMessage userMessage = new UserMessage(userJson);
+        Prompt prompt = new Prompt(systemMessage, userMessage);
+        ChatResponse response = chatModel.call(prompt);
+
+        return responseConverter.convert(response.getResult().getOutput().getText());
+    }
+}

--- a/src/main/java/team/avgmax/rabbit/global/config/SecurityConfig.java
+++ b/src/main/java/team/avgmax/rabbit/global/config/SecurityConfig.java
@@ -57,7 +57,7 @@ public class SecurityConfig {
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/login/**", "/error", "/auth/dummy").permitAll()
                 .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
-                .requestMatchers("/user/**", "/auth/**").hasRole("USER")
+                .requestMatchers("/user/**", "/auth/**", "/ai/**").hasRole("USER")
                 .requestMatchers(HttpMethod.POST, "/fund-bunnies").hasRole("USER")
                 .requestMatchers("/fund-bunnies/**").hasAnyRole("USER", "BUNNY")
                 .anyRequest().hasRole("USER")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,7 +29,14 @@ spring:
           max-idle: 8
           min-idle: 0
           max-wait: -1ms
-    
+  ai:
+    openai:
+      api-key: ${OPENAI_API_KEY:dummy-test-key}
+      chat:
+        options:
+          model: gpt-4.1-nano
+          temperature: 0.7         # 응답 다양성 (0.0 = 고정적, 1.0 = 창의적)
+          max-tokens: 512          # 응답 길이 제한
   security:
     oauth2:
       client:
@@ -66,7 +73,6 @@ spring:
             redirect-uri: ${GITHUB_REDIRECT_URL}
             scope: user:email
             client-name: GitHub
-
         provider:
           google:
             authorization-uri: https://accounts.google.com/o/oauth2/v2/auth


### PR DESCRIPTION
## 📌 작업 개요
- openai api 관련 엔드포인트, 서비스 추가

## ✅ 작업 상세
- Spring AI 의존성 추가
- OpenAI API 키로 ChatGPT 연결
- Controller, Service, SwaggerDoc 작성

## 🎫 관련 이슈
- [RABBIT-37](https://dssw5.atlassian.net/browse/RABBIT-37)

## 🎬 참고 이미지
<img width="1827" height="242" alt="image" src="https://github.com/user-attachments/assets/e1567bc7-fa7f-4015-beb8-335a83be0a6f" />
<img width="638" height="272" alt="image" src="https://github.com/user-attachments/assets/04aadb8a-1cb1-451a-9cc0-1fdb481a0c52" />
<img width="871" height="122" alt="image" src="https://github.com/user-attachments/assets/3a957005-1ff5-4bd8-96b3-f2bb8a4bd4a8" />


## 📎 기타
- Service에 작성한 코드를 기반으로 다른 컨트롤러, 서비스에서 의존성 주입받아  사용하면 될 거 같음
