### PR TITLE
feat: [RABBIT-43] 특정 버니 myList API 구현

### DIFF
--- a/src/main/java/team/avgmax/rabbit/ai/controller/ChatModelApiDocs.java
+++ b/src/main/java/team/avgmax/rabbit/ai/controller/ChatModelApiDocs.java
@@ -10,11 +10,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.oauth2.jwt.Jwt;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import team.avgmax.rabbit.ai.dto.response.ScoreResponse;
-import team.avgmax.rabbit.user.dto.request.UpdatePersonalUserRequest;
-import team.avgmax.rabbit.user.dto.response.*;
 
 @Tag(name = "AI", description = "OpenAI chat API")
 public interface ChatModelApiDocs {

--- a/src/main/java/team/avgmax/rabbit/auth/controller/AuthApiDocs.java
+++ b/src/main/java/team/avgmax/rabbit/auth/controller/AuthApiDocs.java
@@ -18,13 +18,13 @@ import java.util.Map;
 public interface AuthApiDocs {
 
     @Operation(
-        summary = "리프레시 토큰 발급",
-        description = "액세스 토큰이 만료되어 새로운 리프레시 토큰을 발급받습니다."
+        summary = "엑세스 토큰 발급",
+        description = "액세스 토큰이 만료되어 새로운 엑세스 토큰을 발급받습니다."
     )
     @ApiResponses(value = {
         @ApiResponse(
             responseCode = "200",
-            description = "리프레시 토큰 발급 성공",
+            description = "엑세스 토큰 발급 성공",
             content = @Content(
                 mediaType = "application/json",
                 examples = @ExampleObject(

--- a/src/main/java/team/avgmax/rabbit/bunny/controller/BunnyController.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/controller/BunnyController.java
@@ -10,6 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import team.avgmax.rabbit.bunny.dto.response.ChartResponse;
 import team.avgmax.rabbit.bunny.dto.response.FetchBunnyResponse;
+import team.avgmax.rabbit.bunny.dto.response.OrderListResponse;
 import team.avgmax.rabbit.bunny.dto.response.MyBunnyResponse;
 import team.avgmax.rabbit.bunny.entity.enums.BunnyFilter;
 import team.avgmax.rabbit.bunny.entity.enums.ChartInterval;
@@ -57,6 +58,15 @@ public class BunnyController {
         log.info("GET 거래 차트 조회: {}, interval: {}", bunnyName, interval);
 
         return ResponseEntity.ok(bunnyService.getChart(bunnyName, interval));
+    }
+
+    // 특정 버니 마이 리스트 조회
+    @GetMapping("/{bunnyName}/mylist")
+    public ResponseEntity<OrderListResponse> getMyBunnyList(@AuthenticationPrincipal Jwt jwt, @PathVariable String bunnyName) {
+        String userId = jwt.getSubject();
+        log.info("GET 특정 버니 마이 리스트 조회: {}, userId={}", bunnyName, userId);
+
+        return ResponseEntity.ok(bunnyService.getMyBunnyList(bunnyName, userId));
     }
 
     // 버니 좋아요 추가

--- a/src/main/java/team/avgmax/rabbit/bunny/dto/response/OrderListResponse.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/dto/response/OrderListResponse.java
@@ -1,0 +1,22 @@
+package team.avgmax.rabbit.bunny.dto.response;
+
+import java.util.List;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import lombok.Builder;
+
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record OrderListResponse(
+    long size,
+    List<OrderResponse> orders
+) {
+    public static OrderListResponse from(List<OrderResponse> orders) {
+        return OrderListResponse.builder()
+                .size(orders.size())
+                .orders(orders)
+                .build();
+    }
+}

--- a/src/main/java/team/avgmax/rabbit/bunny/dto/response/OrderResponse.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/dto/response/OrderResponse.java
@@ -1,0 +1,34 @@
+package team.avgmax.rabbit.bunny.dto.response;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import team.avgmax.rabbit.bunny.entity.enums.OrderType;
+import team.avgmax.rabbit.bunny.entity.Order;
+
+import lombok.Builder;
+
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record OrderResponse(
+    String orderId,
+    LocalDateTime createdAt,
+    OrderType type,
+    BigDecimal quantity,
+    BigDecimal unitPrice,
+    BigDecimal totalAmount
+) {
+    public static OrderResponse from(Order order) {
+        return OrderResponse.builder()
+                .orderId(order.getId())
+                .createdAt(order.getCreatedAt())
+                .type(order.getOrderType())
+                .quantity(order.getQuantity())
+                .unitPrice(order.getUnitPrice())
+                .totalAmount(order.getQuantity().multiply(order.getUnitPrice())) // 수수료 고려해야됨
+                .build();
+    }
+}

--- a/src/main/java/team/avgmax/rabbit/bunny/repository/OrderRepository.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/repository/OrderRepository.java
@@ -1,0 +1,11 @@
+package team.avgmax.rabbit.bunny.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+import team.avgmax.rabbit.bunny.entity.Order;
+
+public interface OrderRepository extends JpaRepository<Order, String> {
+    List<Order> findAllByBunnyIdAndUserId(String bunnyId, String userId);
+}

--- a/src/main/java/team/avgmax/rabbit/bunny/service/BunnyService.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/service/BunnyService.java
@@ -14,10 +14,13 @@ import team.avgmax.rabbit.bunny.dto.response.ChartDataPoint;
 import team.avgmax.rabbit.bunny.dto.response.ChartResponse;
 import team.avgmax.rabbit.bunny.dto.response.FetchBunnyResponse;
 import team.avgmax.rabbit.bunny.dto.response.MyBunnyResponse;
+import team.avgmax.rabbit.bunny.dto.response.OrderListResponse;
+import team.avgmax.rabbit.bunny.dto.response.OrderResponse;
 import team.avgmax.rabbit.bunny.entity.Badge;
 import team.avgmax.rabbit.bunny.entity.Bunny;
 import team.avgmax.rabbit.bunny.entity.BunnyHistory;
 import team.avgmax.rabbit.bunny.entity.BunnyLike;
+import team.avgmax.rabbit.bunny.entity.Order;
 import team.avgmax.rabbit.bunny.entity.enums.BunnyFilter;
 import team.avgmax.rabbit.bunny.entity.enums.BunnyType;
 import team.avgmax.rabbit.bunny.entity.enums.ChartInterval;
@@ -28,6 +31,7 @@ import team.avgmax.rabbit.bunny.repository.BadgeRepository;
 import team.avgmax.rabbit.bunny.repository.BunnyHistoryRepository;
 import team.avgmax.rabbit.bunny.repository.BunnyRepository;
 import team.avgmax.rabbit.bunny.repository.BunnyLikeRepository;
+import team.avgmax.rabbit.bunny.repository.OrderRepository;
 import team.avgmax.rabbit.user.dto.response.SpecResponse;
 import team.avgmax.rabbit.user.repository.PersonalUserRepository;
 import team.avgmax.rabbit.user.entity.PersonalUser;
@@ -53,6 +57,8 @@ public class BunnyService {
     private final HoldBunnyRepository holdBunnyRepository;
     private final BunnyLikeRepository bunnyLikeRepository;
     private final PersonalUserRepository personalUserRepository;
+    private final OrderRepository orderRepository;
+
 
     // 버니 목록 조회
     @Transactional(readOnly = true) // 읽기 전용
@@ -163,6 +169,22 @@ public class BunnyService {
         return ChartResponse.from(chartData, bunny.getBunnyName(), interval);
     }
 
+    // 특정 버니 마이 리스트 조회
+    @Transactional(readOnly = true)
+    public OrderListResponse getMyBunnyList(String bunnyName, String userId) {
+        Bunny bunny = findBunnyByName(bunnyName);
+
+        List<Order> orders = orderRepository.findAllByBunnyIdAndUserId(bunny.getId(), userId);
+
+        List<OrderResponse> ordersResponse = orders.stream()
+                .map(OrderResponse::from)
+                .toList();
+
+        OrderListResponse myBunnyList = OrderListResponse.from(ordersResponse);
+        return myBunnyList;
+    }
+
+    // 좋아요 추가
     @Transactional
     public void addBunnyLike(String bunnyName, String userId) {
         Bunny bunny = findBunnyByName(bunnyName);
@@ -170,6 +192,7 @@ public class BunnyService {
         bunny.addLikeCount();
     }
 
+    // 좋아요 취소
     @Transactional
     public void cancelBunnyLike(String bunnyName, String userId) {
         Bunny bunny = findBunnyByName(bunnyName);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -108,7 +108,8 @@ app:
       same-site: lax
     redirect-uri: ${FE_REDIRECT_URL}
     jwt:
-      access-expiry: 900  # 15분 (60 * 15)
+#      access-expiry: 900  # 15분 (60 * 15)
+      access-expiry: 86400  # 24시간 (60 * 60 * 24)
       refresh-expiry: 86400  # 24시간 (60 * 60 * 24)
   redis:
     fund-bunny:


### PR DESCRIPTION
## 📌 작업 개요
- 특정 버니 myList API 구현

## ✅ 작업 상세
- trade 페이지에서 사용될, 특정 버니에 대한 내 주문 목록 조회 API를 구현했습니다.

## 🎫 관련 이슈
- [RABBIT-43](https://dssw5.atlassian.net/browse/RABBIT-43)

## 🎬 참고 이미지
- 주문 생성 로직이 없어 테스트를 못했지만 아마 문제 없을 것 같습니다..^^

## 📎 기타
- 액세스 토큰 유효시간을 24시간으로 늘렸습니다.