### PR TITLE
feat: [RABBIT-56] 사용자 프로필 요약 AI 구현

### DIFF
--- a/src/main/java/team/avgmax/rabbit/ai/controller/ChatModelApiDocs.java
+++ b/src/main/java/team/avgmax/rabbit/ai/controller/ChatModelApiDocs.java
@@ -9,9 +9,9 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.RequestParam;
 import team.avgmax.rabbit.ai.dto.response.ScoreResponse;
+import team.avgmax.rabbit.auth.oauth2.CustomOAuth2User;
 
 @Tag(name = "AI", description = "OpenAI chat API")
 public interface ChatModelApiDocs {
@@ -33,7 +33,7 @@ public interface ChatModelApiDocs {
             )
     })
     ResponseEntity<String> ask(
-            @Parameter(description = "JWT 토큰", hidden = true) Jwt jwt,
+            @Parameter(description = "JWT 토큰", hidden = true) CustomOAuth2User customOAuth2User,
             @Parameter(description = "사용자가 입력한 질문") @RequestParam String answer
     );
 
@@ -63,6 +63,6 @@ public interface ChatModelApiDocs {
         )
     })
     ResponseEntity<ScoreResponse> score(
-        @Parameter(description = "JWT 토큰", hidden = true) Jwt jwt
+        @Parameter(description = "JWT 토큰", hidden = true) CustomOAuth2User customOAuth2User
     );
 }

--- a/src/main/java/team/avgmax/rabbit/ai/controller/ChatModelController.java
+++ b/src/main/java/team/avgmax/rabbit/ai/controller/ChatModelController.java
@@ -5,7 +5,6 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -13,6 +12,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 import team.avgmax.rabbit.ai.dto.response.ScoreResponse;
 import team.avgmax.rabbit.ai.service.ChatModelService;
+import team.avgmax.rabbit.auth.oauth2.CustomOAuth2User;
+import team.avgmax.rabbit.user.entity.PersonalUser;
 
 @Slf4j
 @RestController
@@ -23,17 +24,17 @@ public class ChatModelController implements ChatModelApiDocs {
     private final ChatModelService chatModelService;
 
     @GetMapping("/ask")
-    public ResponseEntity<String> ask(@AuthenticationPrincipal Jwt jwt, @RequestParam String answer) {
-        String userId = jwt.getSubject();
+    public ResponseEntity<String> ask(@AuthenticationPrincipal CustomOAuth2User customOAuth2User, @RequestParam String answer) {
+        String userId = customOAuth2User.getPersonalUser().getId();
         log.info("GET /ai/ask: userId={}", userId);
         return ResponseEntity.ok(chatModelService.ask(answer));
     }
 
     @GetMapping("/score")
-    public ResponseEntity<ScoreResponse> score(@AuthenticationPrincipal Jwt jwt) {
-        String personalUserId = jwt.getSubject();
-        log.info("GET /ai/score: userId={}", personalUserId);
+    public ResponseEntity<ScoreResponse> score(@AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+        PersonalUser personalUser = customOAuth2User.getPersonalUser();
+        log.info("GET /ai/score: userId={}", personalUser.getId());
 
-        return ResponseEntity.ok(chatModelService.score(personalUserId));
+        return ResponseEntity.ok(chatModelService.score(personalUser));
     }
 }

--- a/src/main/java/team/avgmax/rabbit/ai/service/ChatClientService.java
+++ b/src/main/java/team/avgmax/rabbit/ai/service/ChatClientService.java
@@ -1,0 +1,96 @@
+package team.avgmax.rabbit.ai.service;
+
+import java.util.stream.Collectors;
+
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import team.avgmax.rabbit.user.entity.PersonalUser;
+import team.avgmax.rabbit.user.entity.Skill;
+
+@Service
+@RequiredArgsConstructor
+public class ChatClientService {
+    private final ChatClient chatClient;
+
+    public String getAiReviewOfUserProfile(PersonalUser user) {
+        String profile = convertProfileToString(user);
+        return chatClient.prompt()
+                .user(u -> u
+                        .text(
+                            """
+                                다음은 한 개발자의 프로필 정보입니다.
+                                {profile}
+                                위 정보를 바탕으로 이 개발자의 역량과 강점을 한 줄로 요약해 주세요.
+                                조건:
+                                - 반드시 한 줄로 작성할 것
+                                - 우선순위 규칙:
+                                1) 경력이 있다면, 종합적 경력 내용을 작성하고 필요시 기술스택과 포지션을 보완적으로 언급할 것. 그 외 정보는 불필요함.
+                                2) 경력이 없다면, 기술스택, 자격증, 학력을 종합적으로 평가해서 작성할 것
+                                - 채용 담당자가 빠르게 이해할 수 있는 간결하고 전문적이고 친절한 표현으로 작성할 것
+                                - 불필요한 수식어나 개인 정보(이름, 생년월일, 이메일)는 포함하지 말 것
+                            """)
+                        .param("profile", profile))
+                .call()
+                .content();
+    }
+
+    public String convertProfileToString(PersonalUser user) {
+        String skill = user.getSkill().isEmpty() ? "없음" : 
+                user.getSkill().stream().map(Skill::getSkillName).collect(Collectors.joining(", "));
+        
+        String certification = user.getCertification().isEmpty() ? "없음" :
+                "[" + user.getCertification().stream()
+                .map(cert -> String.format("""
+                        {
+                            자격증명: %s,
+                            발급 기관: %s,
+                            취득일: %s
+                        }""", cert.getName(), cert.getCa(), cert.getCdate()))
+                .collect(Collectors.joining(", ")) + "]";
+        
+        String career = user.getCareer().isEmpty() ? "없음" :
+                "[" + user.getCareer().stream()
+                .map(c -> String.format("""
+                        {
+                            회사명: %s,
+                            직무: %s,
+                            입사일: %s,
+                            퇴사일: %s
+                        }""", c.getCompanyName(), c.getPosition(), c.getStartDate(), 
+                        c.getEndDate() != null ? c.getEndDate() : "재직 중"))
+                .collect(Collectors.joining(", ")) + "]";
+                
+        String education = user.getEducation().isEmpty() ? "없음" :
+                "[" + user.getEducation().stream()
+                .map(edu -> String.format("""
+                        {
+                            학교명: %s,
+                            전공: %s,
+                            입학일: %s,
+                            졸업일: %s
+                        }""", edu.getSchoolName(), edu.getMajor(), edu.getStartDate(),
+                        edu.getEndDate() != null ? edu.getEndDate() : "재학 중"))
+                .collect(Collectors.joining(", ")) + "]";
+
+
+        return """
+        {
+            이름: %s,
+            포지션: %s,
+            기술스택: %s,
+            자격증: %s,
+            경력: %s,
+            학력: %s
+        }
+        """.formatted(
+            user.getName(),
+            user.getPosition(),
+            skill,
+            certification,
+            career,
+            education
+        );
+    }
+}

--- a/src/main/java/team/avgmax/rabbit/ai/service/ChatModelService.java
+++ b/src/main/java/team/avgmax/rabbit/ai/service/ChatModelService.java
@@ -13,7 +13,6 @@ import org.springframework.transaction.annotation.Transactional;
 import team.avgmax.rabbit.ai.dto.response.ScoreResponse;
 import team.avgmax.rabbit.user.entity.PersonalUser;
 import team.avgmax.rabbit.user.entity.Skill;
-import team.avgmax.rabbit.user.service.PersonalUserService;
 
 import java.util.stream.Collectors;
 
@@ -23,7 +22,6 @@ import java.util.stream.Collectors;
 public class ChatModelService {
 
     private final ChatModel chatModel;
-    private final PersonalUserService personalUserService;
 
     public String ask(String q) {
         UserMessage userMessage = new UserMessage(q);
@@ -33,8 +31,7 @@ public class ChatModelService {
         return response.getResult().getOutput().getText();
     }
 
-    public ScoreResponse score(String personalUserId) {
-        PersonalUser personalUser = personalUserService.findPersonalUserById(personalUserId);
+    public ScoreResponse score(PersonalUser personalUser) {
 
         BeanOutputConverter<ScoreResponse> responseConverter =
                 new BeanOutputConverter<>(ScoreResponse.class);
@@ -89,6 +86,10 @@ public class ChatModelService {
         Prompt prompt = new Prompt(systemMessage, userMessage);
         ChatResponse response = chatModel.call(prompt);
 
-        return responseConverter.convert(response.getResult().getOutput().getText());
+        String responseText = response.getResult().getOutput().getText();
+        if (responseText == null) {
+            throw new IllegalStateException("AI 응답이 null입니다.");
+        }
+        return responseConverter.convert(responseText);
     }
 }

--- a/src/main/java/team/avgmax/rabbit/global/config/AiConfig.java
+++ b/src/main/java/team/avgmax/rabbit/global/config/AiConfig.java
@@ -1,0 +1,53 @@
+package team.avgmax.rabbit.global.config;
+
+import java.io.IOException;
+
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor;
+import org.springframework.ai.chat.memory.ChatMemory;
+import org.springframework.ai.chat.memory.MessageWindowChatMemory;
+import org.springframework.ai.openai.api.OpenAiApi;
+import org.springframework.ai.openai.OpenAiChatOptions;
+import org.springframework.ai.openai.OpenAiChatModel;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AiConfig {
+    @Value("${spring.ai.openai.api-key}")
+    private String openAiApiKey;
+
+    @Bean
+    OpenAiApi openAiApi() {
+        return OpenAiApi.builder()
+                .baseUrl("https://api.openai.com")
+                .apiKey(openAiApiKey)
+                .build();
+    }
+
+    @Bean
+    OpenAiChatModel openAiChatModel(OpenAiApi openAiApi) {
+        return OpenAiChatModel.builder()
+                .openAiApi(openAiApi)
+                .defaultOptions(OpenAiChatOptions.builder()
+                        .model("gpt-4o-mini")
+                        .temperature(0.7)
+                        .maxTokens(512)
+                        .build())
+                .build();
+    }
+
+    @Bean
+    ChatMemory chatMemory() {
+        return MessageWindowChatMemory.builder().build();
+    }
+
+    @Bean
+    ChatClient chatClient(OpenAiChatModel openAiChatModel, ChatMemory chatMemory) throws IOException {
+        
+        return ChatClient.builder(openAiChatModel)
+                .defaultAdvisors(MessageChatMemoryAdvisor.builder(chatMemory).build())
+                .build();
+    }
+}

--- a/src/main/java/team/avgmax/rabbit/user/dto/response/FetchUserResponse.java
+++ b/src/main/java/team/avgmax/rabbit/user/dto/response/FetchUserResponse.java
@@ -14,16 +14,16 @@ public record FetchUserResponse (
     String image,
     String role,
     String carrot,
-    String myBunnyId
+    String myBunnyName
 ) {
-    public static FetchUserResponse from(PersonalUser personalUser, String myBunnyId) {
+    public static FetchUserResponse from(PersonalUser personalUser, String myBunnyName) {
         return FetchUserResponse.builder()
                 .userId(personalUser.getId())
                 .name(personalUser.getName())
                 .image(personalUser.getImage())
                 .role(personalUser.getRole().name())
                 .carrot(personalUser.getCarrot().toString())
-                .myBunnyId(myBunnyId)
+                .myBunnyName(myBunnyName)
                 .build();
     }
 }

--- a/src/main/java/team/avgmax/rabbit/user/dto/response/PersonalUserResponse.java
+++ b/src/main/java/team/avgmax/rabbit/user/dto/response/PersonalUserResponse.java
@@ -24,7 +24,8 @@ public record PersonalUserResponse(
         List<EducationResponse> education,
         List<CareerResponse> career,
         List<CertificationResponse> certification,
-        List<String> skill
+        List<String> skill,
+        String aiReview
 ) {
     public static PersonalUserResponse from(PersonalUser personalUser) {
         return PersonalUserResponse.builder()
@@ -43,6 +44,7 @@ public record PersonalUserResponse(
                 .skill(personalUser.getSkill().stream()
                         .map(Skill::getSkillName)
                         .toList())
+                .aiReview(personalUser.getAiReview())
                 .build();
     }
 }

--- a/src/main/java/team/avgmax/rabbit/user/entity/PersonalUser.java
+++ b/src/main/java/team/avgmax/rabbit/user/entity/PersonalUser.java
@@ -75,6 +75,8 @@ public class PersonalUser extends User {
     @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Education> education = new ArrayList<>();
 
+    String aiReview;
+
     // === 연관관계 편의 메서드 ===
     public void addProvider(UserProvider provider) {
         providers.add(provider);
@@ -128,5 +130,9 @@ public class PersonalUser extends User {
         this.education.addAll(request.education().stream()
             .map(Education::create)
             .toList());
+    }
+
+    public void updateAiReview(String aiReview) {
+        this.aiReview = aiReview;
     }
 }


### PR DESCRIPTION
## 📌 작업 개요
- 사용자 프로필 요약 AI 구현

## ✅ 작업 상세
- 사용자의 프로필(기본정보와 스펙정보)를 이용해 AI Review를 생성하는 로직을 작성했습니다.
- ChatModelService에서 PersonalUserService 의존성을 주입받지 않도록 하기 위해 사용자 객체를 넘겨주는 방식으로 수정했습니다.

## 🎫 관련 이슈
- [RABBIT-56](https://dssw5.atlassian.net/browse/RABBIT-56)

## 🎬 참고 이미지
<img width="792" height="25" alt="스크린샷 2025-09-16 18 58 35" src="https://github.com/user-attachments/assets/29193c12-0ed1-4130-98af-dafcb07c326c" />
<img width="840" height="27" alt="스크린샷 2025-09-16 18 58 20" src="https://github.com/user-attachments/assets/ccc1dc86-99a9-40ff-9ab4-545cac92aa83" />

## 📎 기타
-  답변이 잘 나오기는 하는데 정확도가 낮아서 프롬프트 개선이 필요할 것 같아요.
- PersonalUser에 aiReview 필드 추가했습니다. 이건 프로필 정보만으로 ai 요약을 해주는 필드입니다.