### PR TITLE
feat: [RABBIT-41] 거래 주문 취소 API 구현

### DIFF
--- a/src/main/java/team/avgmax/rabbit/bunny/controller/BunnyController.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/controller/BunnyController.java
@@ -109,4 +109,19 @@ public class BunnyController {
 
         return ResponseEntity.created(location).body(response);
     }
+
+    // 거래 주문 취소
+    @DeleteMapping("/{bunnyName}/orders/{orderId}")
+    public ResponseEntity<Void> cancelOrder(
+            @PathVariable String bunnyName,
+            @PathVariable String orderId,
+            @AuthenticationPrincipal CustomOAuth2User user
+    ) {
+        log.info("DELETE 거래 주문 취소 : bunny={}, orderId={}, user={}", bunnyName, orderId, user.getName());
+
+        PersonalUser principal = user.getPersonalUser();
+        bunnyService.cancelOrder(bunnyName, orderId, principal);
+
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/team/avgmax/rabbit/bunny/exception/BunnyError.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/exception/BunnyError.java
@@ -9,8 +9,11 @@ import team.avgmax.rabbit.global.dto.ErrorCode;
 @RequiredArgsConstructor
 public enum BunnyError implements ErrorCode {
     BUNNY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 버니를 찾을 수 없습니다."),
-    INSUFFICIENT_BALANCE(HttpStatus.BAD_REQUEST, "잔고가 부족합니다."),
-    INSUFFICIENT_HOLDING(HttpStatus.BAD_REQUEST, "보유 수량이 부족합니다.");
+    INSUFFICIENT_BALANCE(HttpStatus.BAD_REQUEST, "보유 캐럿이 부족합니다."),
+    INSUFFICIENT_HOLDING(HttpStatus.BAD_REQUEST, "보유 수량이 부족합니다."),
+    ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 주문을 찾을 수 없습니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "해당 주문을 취소할 권한이 없습니다."),
+    ORDER_ALREADY_FILLED(HttpStatus.CONFLICT, "이미 체결이 완료된 주문은 취소할 수 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/team/avgmax/rabbit/bunny/repository/custom/OrderRepositoryCustom.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/repository/custom/OrderRepositoryCustom.java
@@ -20,4 +20,6 @@ public interface OrderRepositoryCustom {
     List<Order> findAllByUserAndSideOrderByCreatedAtAsc(String userId, OrderType side);
 
     List<Order> findAllByUserAndBunnyAndSideOrderByCreatedAtAsc(String userId, String bunnyId, OrderType side);
+
+    Order findByIdAndBunnyIdForUpdate(String orderId, String bunnyId);
 }

--- a/src/main/java/team/avgmax/rabbit/bunny/repository/custom/OrderRepositoryCustomImpl.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/repository/custom/OrderRepositoryCustomImpl.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import jakarta.persistence.LockModeType;
 import org.springframework.stereotype.Repository;
 
 import com.querydsl.core.types.Projections;
@@ -116,6 +117,20 @@ public class OrderRepositoryCustomImpl implements OrderRepositoryCustom {
                 )
                 .orderBy(order.createdAt.asc())
                 .fetch();
+    }
+
+    @Override
+    public Order findByIdAndBunnyIdForUpdate(String orderId, String bunnyId) {
+        QOrder order = QOrder.order;
+
+        return queryFactory
+                .selectFrom(order)
+                .where(
+                        order.id.eq(orderId),
+                        order.bunny.id.eq(bunnyId)
+                )
+                .setLockMode(LockModeType.PESSIMISTIC_WRITE)
+                .fetchFirst();
     }
 
 }


### PR DESCRIPTION
## 📌 작업 개요
- feat: [RABBIT-41] 거래 주문 취소 API 구현

## ✅ 작업 상세
- 거래 주문 취소 로직 (controller, service, repository)

## 🎫 관련 이슈
- [RABBIT-41](https://dssw5.atlassian.net/browse/RABBIT-41)

## 🎬 참고 이미지
- (테스트 성공한 이미지 첨부)

## 📎 기타
- 없음