### PR TITLE
fix: [RABBIT-62] BE 엔드포인트 전역적으로 api 추가

### DIFF
--- a/src/main/java/team/avgmax/rabbit/global/config/AiConfig.java
+++ b/src/main/java/team/avgmax/rabbit/global/config/AiConfig.java
@@ -18,6 +18,15 @@ public class AiConfig {
     @Value("${spring.ai.openai.api-key}")
     private String openAiApiKey;
 
+    @Value("${spring.ai.openai.chat.options.model}")
+    private String openAiModel;
+
+    @Value("${spring.ai.openai.chat.options.temperature}")
+    private Double openAiTemperature;
+
+    @Value("${spring.ai.openai.chat.options.max-tokens}")
+    private Integer openAiMaxTokens;    
+
     @Bean
     OpenAiApi openAiApi() {
         return OpenAiApi.builder()
@@ -31,9 +40,9 @@ public class AiConfig {
         return OpenAiChatModel.builder()
                 .openAiApi(openAiApi)
                 .defaultOptions(OpenAiChatOptions.builder()
-                        .model("gpt-4o-mini")
-                        .temperature(0.7)
-                        .maxTokens(512)
+                        .model(openAiModel)
+                        .temperature(openAiTemperature)
+                        .maxTokens(openAiMaxTokens)
                         .build())
                 .build();
     }

--- a/src/main/java/team/avgmax/rabbit/global/config/SecurityConfig.java
+++ b/src/main/java/team/avgmax/rabbit/global/config/SecurityConfig.java
@@ -45,7 +45,7 @@ public class SecurityConfig {
             .formLogin(AbstractHttpConfigurer::disable)
             .httpBasic(AbstractHttpConfigurer::disable)
             .oauth2Login(oauth2 -> oauth2
-                .authorizationEndpoint(endpoint -> endpoint.baseUri("/oauth2/authorization")) // 기본값
+                .authorizationEndpoint(endpoint -> endpoint.baseUri("/oauth2/authorization"))
                 .redirectionEndpoint(redirection -> redirection.baseUri("/login/oauth2/code/*"))
                 .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))
                 .successHandler(customSuccessHandler)
@@ -71,11 +71,9 @@ public class SecurityConfig {
 
     @Bean
     Converter<Jwt, ? extends AbstractAuthenticationToken> jwtAuthenticationConverter() {
-        // 1) scope/scp -> SCOPE_*
-        var scopeConverter = new JwtGrantedAuthoritiesConverter(); // 기본값
+        var scopeConverter = new JwtGrantedAuthoritiesConverter(); // Scopes
 
-        // 2) roles -> 그대로(이미 ROLE_* 이므로 prefix 추가 X)
-        var rolesConverter = new JwtGrantedAuthoritiesConverter();
+        var rolesConverter = new JwtGrantedAuthoritiesConverter(); // Roles
         rolesConverter.setAuthoritiesClaimName("roles");
         rolesConverter.setAuthorityPrefix("");
 

--- a/src/main/java/team/avgmax/rabbit/global/config/SwaggerConfig.java
+++ b/src/main/java/team/avgmax/rabbit/global/config/SwaggerConfig.java
@@ -22,8 +22,8 @@ public class SwaggerConfig {
                         .version("1.0.0")
                 )
                 .servers(List.of(
-                        new Server().url("https://rabbit.avgmax.team").description("운영 서버"),
-                        new Server().url("http://localhost:8080").description("개발 서버")
+                        new Server().url("https://rabbit.avgmax.team/api").description("운영 서버"),
+                        new Server().url("http://localhost:8080/api").description("개발 서버")
                 ))
                 .components(new io.swagger.v3.oas.models.Components()
                         .addSecuritySchemes("bearerAuth", new SecurityScheme()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -118,6 +118,8 @@ app:
 
 server:
   port: 8080
+  servlet:
+    context-path: /api
 
 logging:
   level:


### PR DESCRIPTION
## 📌 작업 개요
-  BE 엔드포인트 전역적으로 api 추가

## ✅ 작업 상세
- servlet context-path에 /api 추가
- nginx에서 rewrite 제거
- oauth 앱과 .env 에도 /api 수정

## 🎫 관련 이슈
- [RABBIT-62](https://dssw5.atlassian.net/browse/RABBIT-62)

## 🎬 참고 이미지
<img width="1857" height="633" alt="image" src="https://github.com/user-attachments/assets/656d8185-d402-4c9c-98e1-b02f1984095d" />

## 📎 기타
- 없음.