### PR TITLE
refactor: [RABBIT-79] 인가 및 로그아웃 로직 수정

### DIFF
--- a/src/main/java/team/avgmax/rabbit/auth/controller/AuthApiDocs.java
+++ b/src/main/java/team/avgmax/rabbit/auth/controller/AuthApiDocs.java
@@ -12,6 +12,7 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import java.io.IOException;
 import java.util.Map;
 
 @Tag(name = "Auth", description = "인증 API")
@@ -86,7 +87,7 @@ public interface AuthApiDocs {
             description = "로그아웃 성공"
         )
     })
-    ResponseEntity<Void> logout(HttpServletResponse response);
+    void logout(HttpServletResponse response) throws IOException;
 
     @Operation(
         summary = "더미 토큰 발급",

--- a/src/main/java/team/avgmax/rabbit/auth/controller/AuthController.java
+++ b/src/main/java/team/avgmax/rabbit/auth/controller/AuthController.java
@@ -14,6 +14,7 @@ import org.springframework.security.oauth2.jwt.*;
 import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
 import org.springframework.web.bind.annotation.*;
 
+import java.io.IOException;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Map;
@@ -74,7 +75,7 @@ public class AuthController implements AuthApiDocs {
                     .build();
 
             response.setHeader(HttpHeaders.SET_COOKIE, accessCookie.toString());
-
+            
             return ResponseEntity.ok(Map.of("message", "new access token issued"));
 
         } catch (JwtException e) {
@@ -91,7 +92,7 @@ public class AuthController implements AuthApiDocs {
     }
 
     @GetMapping("/logout")
-    public ResponseEntity<Void> logout(HttpServletResponse response) {
+    public void logout(HttpServletResponse response) throws IOException {
         // ACCESS_TOKEN 만료
         ResponseCookie accessCookie = ResponseCookie.from("ACCESS_TOKEN", "")
                 .httpOnly(true)
@@ -113,7 +114,7 @@ public class AuthController implements AuthApiDocs {
         response.addHeader(HttpHeaders.SET_COOKIE, accessCookie.toString());
         response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
 
-        return ResponseEntity.noContent().build(); // 204 No Content
+        response.sendRedirect("/");
     }
 
     @GetMapping("/dummy")

--- a/src/main/java/team/avgmax/rabbit/auth/oauth2/CookieBearerTokenResolver.java
+++ b/src/main/java/team/avgmax/rabbit/auth/oauth2/CookieBearerTokenResolver.java
@@ -12,19 +12,21 @@ public class CookieBearerTokenResolver implements BearerTokenResolver {
 
     @Override
     public String resolve(HttpServletRequest request) {
-        // 1. Authorization 헤더에서 Bearer 토큰 있으면 추출
-        String authHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
-        if (StringUtils.hasText(authHeader) && authHeader.startsWith("Bearer ")) {
-            return authHeader.substring(7);
-        }
-
-        // 2. 쿠키에서 ACCESS_TOKEN 있으면 추출
+        // 1. 쿠키에서 ACCESS_TOKEN 있으면 추출 (쿠키 먼저 확인)
         if (request.getCookies() != null) {
             for (Cookie cookie : request.getCookies()) {
                 if ("ACCESS_TOKEN".equals(cookie.getName())) {
                     return cookie.getValue();
                 }
             }
+        }
+
+        // 2. Authorization 헤더에서 Bearer 토큰 확인
+        String authHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (StringUtils.hasText(authHeader) 
+                && authHeader.startsWith("Bearer ")
+                && !"Bearer undefined".equals(authHeader)) {
+            return authHeader.substring(7);
         }
 
         return null;

--- a/src/main/java/team/avgmax/rabbit/auth/oauth2/CustomSuccessHandler.java
+++ b/src/main/java/team/avgmax/rabbit/auth/oauth2/CustomSuccessHandler.java
@@ -94,9 +94,6 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         response.addHeader(HttpHeaders.SET_COOKIE, accessCookie.toString());
         response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
 
-        response.setContentType("application/json;charset=UTF-8");
-        response.getWriter().write("{\"message\": \"login success\"}");
-
         response.sendRedirect(redirectUri);
     }
 }


### PR DESCRIPTION
## 📌 작업 개요
- 인증/ 인가 및 로그아웃 로직 수정

## ✅ 작업 상세
- 기존은 헤더를 먼저 확인하고 쿠키를 확인했는데, 이 경우 프론트의 테스트용 인증 (헤더 사용 방식) 코드에 값은 없지만 헤더는 존재해 인가 실패로 처리됨 -> 이 부분을 쿠키 먼저 확인하고 없으면 헤더 확인하도록 변경
<img width="708" height="431" alt="image" src="https://github.com/user-attachments/assets/3e56191b-5b3b-411a-8dea-ff23a1347834" />

- 로그아웃 시 /로 리다이렉션 시키는 기능 추가
- 로그인 시 json 과 리다이렉션 요청을 동시에 보내는 코드 중 json 부분 제거 (거의 없지만 충돌(?) 가능성 있다고 함)

## 🎫 관련 이슈
- [RABBIT-79](https://dssw5.atlassian.net/browse/RABBIT-79)

## 🎬 참고 이미지
<img width="1733" height="715" alt="image" src="https://github.com/user-attachments/assets/22cf84e0-4a67-4f2c-95cc-e7b71485c14c" />

## 📎 기타
- 없음.