### PR TITLE
fix: [RABBIT-68] 엔티티 필드 수정

### DIFF
--- a/src/main/java/team/avgmax/rabbit/bunny/controller/BunnyController.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/controller/BunnyController.java
@@ -21,6 +21,7 @@ import team.avgmax.rabbit.bunny.entity.enums.ChartInterval;
 import team.avgmax.rabbit.bunny.service.BunnyService;
 import team.avgmax.rabbit.bunny.dto.response.OrderResponse;
 import team.avgmax.rabbit.user.entity.PersonalUser;
+import team.avgmax.rabbit.user.entity.enums.Role;
 
 import java.net.URI;
 import java.util.List;
@@ -80,17 +81,25 @@ public class BunnyController {
     @PostMapping("/{bunnyName}/like")
     public ResponseEntity<Void> addBunnyLike(@AuthenticationPrincipal Jwt jwt, @PathVariable String bunnyName) {
         String userId = jwt.getSubject();
-        log.info("POST 버니 좋아요 추가: {}", bunnyName);
-        bunnyService.addBunnyLike(bunnyName, userId);
+        
+        @SuppressWarnings("unchecked")
+        Role userRole = Role.valueOf(((List<String>) jwt.getClaim("roles")).get(0));
+        
+        log.info("POST 버니 좋아요 추가: {}, role={}", bunnyName, userRole);
+        bunnyService.addBunnyLike(bunnyName, userId, userRole);
         return ResponseEntity.ok().build();
     }
 
-    // 버니 좋아요 취소
+    // 버니 좋아요 취소  
     @DeleteMapping("/{bunnyName}/like")
     public ResponseEntity<Void> cancelBunnyLike(@AuthenticationPrincipal Jwt jwt, @PathVariable String bunnyName) {
         String userId = jwt.getSubject();
-        log.info("DELETE 버니 좋아요 취소: {}", bunnyName);
-        bunnyService.cancelBunnyLike(bunnyName, userId);
+        
+        @SuppressWarnings("unchecked")
+        Role userRole = Role.valueOf(((List<String>) jwt.getClaim("roles")).get(0));
+        
+        log.info("DELETE 버니 좋아요 취소: {}, role={}", bunnyName, userRole);
+        bunnyService.cancelBunnyLike(bunnyName, userId, userRole);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/team/avgmax/rabbit/bunny/dto/orderBook/OrderBookDiff.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/dto/orderBook/OrderBookDiff.java
@@ -1,7 +1,5 @@
 package team.avgmax.rabbit.bunny.dto.orderBook;
 
-import team.avgmax.rabbit.bunny.entity.Bunny;
-
 import java.math.BigDecimal;
 import java.util.List;
 

--- a/src/main/java/team/avgmax/rabbit/bunny/dto/orderBook/OrderBookLevel.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/dto/orderBook/OrderBookLevel.java
@@ -1,7 +1,6 @@
 package team.avgmax.rabbit.bunny.dto.orderBook;
 
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
 
 public record OrderBookLevel(
         BigDecimal price,      // 해당 가격 레벨 대의 가격

--- a/src/main/java/team/avgmax/rabbit/bunny/dto/response/FetchBunnyResponse.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/dto/response/FetchBunnyResponse.java
@@ -7,16 +7,13 @@ import lombok.Builder;
 import lombok.Getter;
 import team.avgmax.rabbit.bunny.entity.Badge;
 import team.avgmax.rabbit.bunny.entity.Bunny;
-import team.avgmax.rabbit.bunny.entity.enums.BadgeImg;
 import team.avgmax.rabbit.bunny.entity.enums.BunnyType;
 import team.avgmax.rabbit.bunny.entity.enums.DeveloperType;
 import team.avgmax.rabbit.user.entity.enums.Position;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
-import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Getter
 @Builder
@@ -40,14 +37,14 @@ public class FetchBunnyResponse {
     private BigDecimal fluctuationRate; // 등락률
 
     // 지표 (Entity 지표 미정)
-    private BigDecimal Indicator1; // 지표 1 (성장형 이었던 것)
-    private BigDecimal Indicator2; // 지표 2 (안정형)
-    private BigDecimal Indicator3; // 지표 3 (가치형)
-    private BigDecimal Indicator4; // 지표 4 (인기형)
-    private BigDecimal Indicator5; // 지표 5 (밸런스형)
+    private int growth; // 지표 1 (성장성)
+    private int stability; // 지표 2 (안정성)
+    private int value; // 지표 3 (가치)
+    private int popularity; // 지표 4 (인기)
+    private int balance; // 지표 5 (밸런스)
 
     // 배지
-    private List<BadgeImg> badges;
+    private List<String> badges;
 
     // 좋아요 수
     private long likeCount;
@@ -55,28 +52,24 @@ public class FetchBunnyResponse {
     // 시간
     private LocalDateTime createdAt; // 생성시간
 
-    public static FetchBunnyResponse from(Bunny bunny, List<Badge> badges) {
-        List<BadgeImg> badgeImgs = (badges != null)
-                ? badges.stream().map(Badge::getBadgeImg).collect(Collectors.toList())
-                : Collections.emptyList(); // NullPointException 을 대비하면서 null 이면 빈 list 를 사용할 수 있도록 함.
-
+    public static FetchBunnyResponse from(Bunny bunny) {
         return FetchBunnyResponse.builder()
                 .bunnyId(bunny.getId())
                 .userName(bunny.getUser().getName())
                 .bunnyName(bunny.getBunnyName())
                 .developerType(bunny.getDeveloperType())
                 .bunnyType(bunny.getBunnyType())
-                .position(bunny.getPosition())
+                .position(bunny.getUser().getPosition())
                 .reliability(bunny.getReliability())
                 .currentPrice(bunny.getCurrentPrice())
                 .closingPrice(bunny.getClosingPrice())
                 .marketCap(bunny.getMarketCap())
-//                .Indicator1(bunny.)
-//                .Indicator2(bunny.)
-//                .Indicator3(bunny.)
-//                .Indicator4(bunny.)
-//                .Indicator5(bunny.)
-                .badges(badgeImgs)
+                .growth(bunny.getGrowth())
+                .stability(bunny.getStability())
+                .value(bunny.getValue())
+                .popularity(bunny.getPopularity())
+                .balance(bunny.getBalance())
+                .badges(bunny.getBadges().stream().map(Badge::getBadgeImg).toList())
                 .likeCount(bunny.getLikeCount())
                 .createdAt(bunny.getCreatedAt())
                 .build();

--- a/src/main/java/team/avgmax/rabbit/bunny/dto/response/MyBunnyResponse.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/dto/response/MyBunnyResponse.java
@@ -8,7 +8,6 @@ import team.avgmax.rabbit.bunny.dto.data.ComparisonData;
 import team.avgmax.rabbit.bunny.dto.data.DailyPriceData;
 import team.avgmax.rabbit.bunny.dto.data.MyBunnyByDevTypeData;
 import team.avgmax.rabbit.bunny.dto.data.MyBunnyByHolderData;
-import team.avgmax.rabbit.bunny.entity.Badge;
 import team.avgmax.rabbit.bunny.entity.enums.BunnyType;
 import team.avgmax.rabbit.bunny.entity.enums.DeveloperType;
 import team.avgmax.rabbit.user.dto.response.SpecResponse;
@@ -32,7 +31,7 @@ public class MyBunnyResponse {
     private BunnyType bunnyType; // 버니 유형 (희소, 밸런스, 단가)
     private DeveloperType developerType; //  개발자 유형
     private Position position; // 직군
-    private List<Badge> badges; // 배지
+    private List<String> badges; // 배지
     private LocalDate todayTime; // 오늘 날짜
 
     // 요구사항 2: 성장성(차트)
@@ -57,11 +56,11 @@ public class MyBunnyResponse {
     private BigDecimal myGrowthRate;
 
     // 요구사항 7: 개발자 유형 지표
-    private BigDecimal indicator1;
-    private BigDecimal indicator2;
-    private BigDecimal indicator3;
-    private BigDecimal indicator4;
-    private BigDecimal indicator5;
+    private int growth;
+    private int stability;
+    private int value;
+    private int popularity;
+    private int balance;
 
     // 요구사항 9: 내 코인을 보유한 유형 및 보유자 확인
     private List<MyBunnyByDevTypeData> holderTypes;

--- a/src/main/java/team/avgmax/rabbit/bunny/entity/Badge.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/entity/Badge.java
@@ -3,7 +3,6 @@ package team.avgmax.rabbit.bunny.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
-import team.avgmax.rabbit.bunny.entity.enums.BadgeImg;
 import team.avgmax.rabbit.bunny.entity.id.BadgeId;
 import team.avgmax.rabbit.global.entity.BaseTime;
 
@@ -23,6 +22,13 @@ public class Badge extends BaseTime {
     @Column(name = "user_id", length = 26, nullable = false)
     private String userId;
 
-    @Enumerated(EnumType.STRING)
-    private BadgeImg badgeImg;
+    private String badgeImg;
+
+    public static Badge create(String bunnyId, String userId, String corporationName) {
+        return Badge.builder()
+                .bunnyId(bunnyId)
+                .userId(userId)
+                .badgeImg(corporationName)
+                .build();
+    }
 }

--- a/src/main/java/team/avgmax/rabbit/bunny/entity/Bunny.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/entity/Bunny.java
@@ -10,9 +10,10 @@ import team.avgmax.rabbit.bunny.entity.enums.DeveloperType;
 import team.avgmax.rabbit.funding.entity.FundBunny;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
 
 import team.avgmax.rabbit.user.entity.PersonalUser;
-import team.avgmax.rabbit.user.entity.enums.Position;
 
 @Entity
 @Getter
@@ -26,7 +27,7 @@ public class Bunny extends BaseTime {
     @Builder.Default
     private String id = UlidGenerator.generateMonotonic();
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private PersonalUser user;
 
@@ -38,9 +39,6 @@ public class Bunny extends BaseTime {
 
     @Enumerated(EnumType.STRING)
     private BunnyType bunnyType;
-   
-    @Enumerated(EnumType.STRING)
-    private Position position;
 
     private BigDecimal reliability;
 
@@ -50,7 +48,15 @@ public class Bunny extends BaseTime {
 
     private BigDecimal marketCap;
 
-    // 5가지 성장 지표 추후 추가
+    private int growth;
+
+    private int stability;
+
+    private int value;
+
+    private int popularity;
+
+    private int balance;
     
     private String aiReview;
 
@@ -58,13 +64,17 @@ public class Bunny extends BaseTime {
 
     private long likeCount;
 
+    @Builder.Default
+    @JoinColumn(name = "bunny_id")
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Badge> badges = new ArrayList<>();
+
     public static Bunny create(FundBunny fundBunny) {
         return Bunny.builder()
                 .user(fundBunny.getUser())
                 .bunnyName(fundBunny.getBunnyName())
-                .developerType(DeveloperType.GROWTH) // 추후 기본값 지정
+                .developerType(DeveloperType.UNDEFINED)
                 .bunnyType(fundBunny.getType())
-                .position(fundBunny.getUser().getPosition())
                 .reliability(BigDecimal.ZERO) // 추후 계산 로직 추가
                 .currentPrice(fundBunny.getType().getPrice())
                 .closingPrice(fundBunny.getType().getPrice())

--- a/src/main/java/team/avgmax/rabbit/bunny/entity/enums/DeveloperType.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/entity/enums/DeveloperType.java
@@ -1,10 +1,10 @@
 package team.avgmax.rabbit.bunny.entity.enums;
 
 public enum DeveloperType {
+    UNDEFINED, // 미발행자는 개발자 유형이 없으므로
     GROWTH,
     STABLE,
     VALUE,
     POPULAR,
-    BALANCE,
-    UNDEFINED // 미발행자는 개발자 유형이 없으므로
+    BALANCE
 }

--- a/src/main/java/team/avgmax/rabbit/bunny/repository/BadgeRepository.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/repository/BadgeRepository.java
@@ -11,4 +11,6 @@ public interface BadgeRepository extends JpaRepository<Badge, BadgeId> {
     List<Badge> findAllByBunnyIdIn(List<String> bunnyIds);
 
     List<Badge> findAllByBunnyId(String bunnyId);
+
+    void deleteByBunnyIdAndUserId(String bunnyId, String userId);
 }

--- a/src/main/java/team/avgmax/rabbit/bunny/repository/custom/BunnyRepositoryCustomImpl.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/repository/custom/BunnyRepositoryCustomImpl.java
@@ -47,7 +47,7 @@ public class BunnyRepositoryCustomImpl implements BunnyRepositoryCustom{
 
     @Override
     public BigDecimal findAverageGrowthRateByPosition(Position position) {
-        return calculateAverageGrowthRate(bunny.position.eq(position));
+        return calculateAverageGrowthRate(bunny.user.position.eq(position));
     }
 
     @Override

--- a/src/main/java/team/avgmax/rabbit/funding/controller/FundingApiDocs.java
+++ b/src/main/java/team/avgmax/rabbit/funding/controller/FundingApiDocs.java
@@ -189,18 +189,23 @@ public interface FundingApiDocs {
                         "my_account_c": 233000000,
                         "spec": {
                             "name": "정재웅",
-                            "birthdate": "1999-08-20",
+                            "email": "jungjaewoong@example.com",
+                            "phone": "010-1234-5678",
                             "image": "https://picsum.photos/200",
                             "resume": "https://resumeurl",
                             "position": "BACKEND",
-                            "sns": [
+                            "link": [
                                 {
-                                    "url": "https://url1.com",
-                                    "image": "https://picsum.photos/200"
+                                    "sns_id": "01HZXSNS00000000000000001",
+                                    "url": "https://github.com/example",
+                                    "type": "GITHUB",
+                                    "favicon": "https://github.com/favicon.ico"
                                 },
                                 {
-                                    "url": "https://url2.com",
-                                    "image": "https://picsum.photos/200"
+                                    "sns_id": "01HZXSNS00000000000000002",
+                                    "url": "https://linkedin.com/in/example",
+                                    "type": "LINKEDIN",
+                                    "favicon": "https://linkedin.com/favicon.ico"
                                 }
                             ],
                             "skill": [
@@ -209,12 +214,14 @@ public interface FundingApiDocs {
                             ],
                             "certification": [
                                 {
+                                    "certification_id": "01HZXCERT0000000000000001",
                                     "certificate_url": "https://certificationurl1",
                                     "name": "정보처리기사",
                                     "ca": "에이비지맥스",
                                     "cdate": "2015-09-01"
                                 },
                                 {
+                                    "certification_id": "01HZXCERT0000000000000002",
                                     "certificate_url": "https://certificationurl2",
                                     "name": "SQLD",
                                     "ca": "에이비지맥스",
@@ -223,6 +230,7 @@ public interface FundingApiDocs {
                             ],
                             "career": [
                                 {
+                                    "career_id": "01HZXCAREER00000000000001",
                                     "company_name": "에이비지맥스",
                                     "status": "EMPLOYED",
                                     "position": "백엔드 개발자",
@@ -231,6 +239,7 @@ public interface FundingApiDocs {
                                     "certificate_url": "https://companycerturl.com/career1"
                                 },
                                 {
+                                    "career_id": "01HZXCAREER00000000000002",
                                     "company_name": "테크스타트업",
                                     "status": "UNEMPLOYED",
                                     "position": "주니어 개발자",
@@ -241,24 +250,25 @@ public interface FundingApiDocs {
                             ],
                             "education": [
                                 {
+                                    "education_id": "01HZXEDU00000000000000001",
                                     "school_name": "서울대학교",
                                     "status": "ENROLLED",
                                     "major": "컴퓨터공학과",
                                     "start_date": "2015-03-01",
                                     "end_date": "2019-02-28",
-                                    "certificate_url": "https://eduurl.com/snu",
-                                    "priority": 1
+                                    "certificate_url": "https://eduurl.com/snu"
                                 },
                                 {
+                                    "education_id": "01HZXEDU00000000000000002",
                                     "school_name": "서울고등학교",
                                     "status": "GRADUATED",
                                     "major": "자연계열",
                                     "start_date": "2012-03-01",
                                     "end_date": "2015-02-28",
-                                    "certificate_url": "https://eduurl.com/seoulhs",
-                                    "priority": 2
+                                    "certificate_url": "https://eduurl.com/seoulhs"
                                 }
-                            ]
+                            ],
+                            "ai_review": "이 개발자는 백엔드 개발 경험이 풍부하고 Java, SpringBoot 기술 스택에 능숙합니다. 정보처리기사와 SQLD 자격증을 보유하고 있어 데이터베이스 관련 업무에도 전문성을 가지고 있습니다."
                         }
                     }
                     """

--- a/src/main/java/team/avgmax/rabbit/user/controller/PersonalUserApiDocs.java
+++ b/src/main/java/team/avgmax/rabbit/user/controller/PersonalUserApiDocs.java
@@ -40,7 +40,7 @@ public interface PersonalUserApiDocs {
                         "image": "https://picsum.photos/200",
                         "role": "ROLE_USER",
                         "carrot": "1000000",
-                        "my_bunny_id": "01HZXBUNNY00000000000000001"
+                        "my_bunny_name": "bunny-001"
                     }
                     """
                 )
@@ -72,19 +72,19 @@ public interface PersonalUserApiDocs {
                             "sns_id": "01HZXSNS00000000000000001",
                             "url": "https://github.com/jjweidon",
                             "type": "GITHUB",
-                            "favicon": "https://github.com/favicon"
+                            "favicon": "https://github.com/favicon.ico"
                         },
                         {
                             "sns_id": "01HZXSNS00000000000000002",
                             "url": "https://instagram.com/jwoong_8",
                             "type": "INSTAGRAM",
-                            "favicon": "https://instagram.com/favicon"
+                            "favicon": "https://instagram.com/favicon.ico"
                         },
                         {
                             "sns_id": "01HZXSNS00000000000000003",
                             "url": "https://linkedin.com/jwoong_8",
                             "type": "LINKEDIN",
-                            "favicon": "https://linkedin.com/favicon"
+                            "favicon": "https://linkedin.com/favicon.ico"
                         }
                     ],
                     "position": "BACKEND",
@@ -185,19 +185,19 @@ public interface PersonalUserApiDocs {
                                 "sns_id": "01HZXSNS00000000000000001",
                                 "link": "https://github.com/jjweidon",
                                 "type": "GITHUB",
-                                "favicon": "https://github.com/favicon"
+                                "favicon": "https://github.com/favicon.ico"
                             },
                             {
                                 "sns_id": "01HZXSNS00000000000000002",
                                 "link": "https:/instagram.com/jwoong_8",
                                 "type": "INSTAGRAM",
-                                "favicon": "https:/instagram.com/favicon"
+                                "favicon": "https:/instagram.com/favicon.ico"
                             },
                             {
                                 "sns_id": "01HZXSNS00000000000000003",
                                 "link": "https:/linkedin.com/jwoong_8",
                                 "type": "LINKEDIN",
-                                "favicon": "https:/linkedin.com/favicon"
+                                "favicon": "https:/linkedin.com/favicon.ico"
                             }
                         ],
                         "position": "BACKEND",

--- a/src/main/java/team/avgmax/rabbit/user/dto/response/SpecResponse.java
+++ b/src/main/java/team/avgmax/rabbit/user/dto/response/SpecResponse.java
@@ -1,7 +1,6 @@
 package team.avgmax.rabbit.user.dto.response;
 
 import java.time.LocalDate;
-
 import java.util.List;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
@@ -16,27 +15,33 @@ import team.avgmax.rabbit.user.entity.enums.Position;
 public record SpecResponse(
     String name,
     LocalDate birthdate,
+    String email,
+    String phone,
     String image,
     String resume,
     Position position,
-    List<SnsResponse> sns,
+    List<SnsResponse> link,
     List<String> skill,
     List<CertificationResponse> certification,
     List<CareerResponse> career,
-    List<EducationResponse> education
+    List<EducationResponse> education,
+    String aiReview
 ) {
     public static SpecResponse from(PersonalUser user) {
         return SpecResponse.builder()
             .name(user.getName())
             .birthdate(user.getBirthdate())
+            .email(user.getEmail())
+            .phone(user.getPhone())
             .image(user.getImage())
             .resume(user.getResume())
             .position(user.getPosition())
-            .sns(SnsResponse.from(user.getSns()))
+            .link(SnsResponse.from(user.getSns()))
             .skill(user.getSkill().stream().map(Skill::getSkillName).toList())
             .certification(CertificationResponse.from(user.getCertification()))
             .career(CareerResponse.from(user.getCareer()))
             .education(EducationResponse.from(user.getEducation()))
+            .aiReview(user.getAiReview())
             .build();
     }
 }

--- a/src/main/java/team/avgmax/rabbit/user/entity/CorporationUser.java
+++ b/src/main/java/team/avgmax/rabbit/user/entity/CorporationUser.java
@@ -17,7 +17,7 @@ public class CorporationUser extends User {
     @Builder.Default
     private String id = UlidGenerator.generateMonotonic();
 
-    private String name;
+    private String corporationName;
 
     private String bin;
 

--- a/src/main/java/team/avgmax/rabbit/user/repository/CorporationUserRepository.java
+++ b/src/main/java/team/avgmax/rabbit/user/repository/CorporationUserRepository.java
@@ -1,0 +1,7 @@
+package team.avgmax.rabbit.user.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import team.avgmax.rabbit.user.entity.CorporationUser;
+
+public interface CorporationUserRepository extends JpaRepository<CorporationUser, String> {
+}

--- a/src/main/java/team/avgmax/rabbit/user/service/PersonalUserService.java
+++ b/src/main/java/team/avgmax/rabbit/user/service/PersonalUserService.java
@@ -30,7 +30,6 @@ import team.avgmax.rabbit.user.repository.custom.HoldBunnyRepositoryCustomImpl;
 import team.avgmax.rabbit.bunny.repository.custom.MatchRepositoryCustomImpl;
 import team.avgmax.rabbit.bunny.repository.custom.OrderRepositoryCustomImpl;
 
-
 @Service
 @RequiredArgsConstructor
 public class PersonalUserService {


### PR DESCRIPTION
## 📌 작업 개요
- 엔티티 필드 수정

## ✅ 작업 상세
- Corporation에 corporationName 추가
- Bunny에 position 제거
- Bunny에 개발자 유형 지표 5가지 추가
- 뱃지 img를 확장성을 고려하여 enum 대신 String을 사용하도록 수정
    - 추후 corporation의 name or image를 사용하도록 할 것
- Bunny에 Badge 1:N 연관관계를추가해서 뱃지 조회가 쉽도록 수정
- 뱃지 추가/삭제 API 만들었는데, Role문제로 동작은 안함

## 🎫 관련 이슈
- [RABBIT-68](https://dssw5.atlassian.net/browse/RABBIT-68)

## 🎬 참고 이미지

## 📎 기타
- 아마존 sdk 구버전을 사용하고 있다는 경고가 확인됩니다.
<img width="1793" height="140" alt="image" src="https://github.com/user-attachments/assets/c594e2c3-89f5-4919-9259-1c86e9638fc9" />
<img width="802" height="263" alt="image" src="https://github.com/user-attachments/assets/66962626-7022-49f9-8830-aec9e5bfd32f" />
