### PR TITLE
feat: [RABBIT-80] 보유 버니 통계 조회 API 구현

### DIFF
--- a/src/main/java/team/avgmax/rabbit/bunny/entity/Bunny.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/entity/Bunny.java
@@ -73,7 +73,7 @@ public class Bunny extends BaseTime {
         return Bunny.builder()
                 .user(fundBunny.getUser())
                 .bunnyName(fundBunny.getBunnyName())
-                .developerType(DeveloperType.UNDEFINED)
+                .developerType(DeveloperType.BASIC)
                 .bunnyType(fundBunny.getType())
                 .reliability(BigDecimal.ZERO) // 추후 계산 로직 추가
                 .currentPrice(fundBunny.getType().getPrice())

--- a/src/main/java/team/avgmax/rabbit/bunny/entity/enums/DeveloperType.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/entity/enums/DeveloperType.java
@@ -1,7 +1,7 @@
 package team.avgmax.rabbit.bunny.entity.enums;
 
 public enum DeveloperType {
-    UNDEFINED, // 미발행자는 개발자 유형이 없으므로
+    BASIC, // 기본형
     GROWTH,
     STABLE,
     VALUE,

--- a/src/main/java/team/avgmax/rabbit/bunny/service/BunnyService.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/service/BunnyService.java
@@ -455,7 +455,7 @@ public class BunnyService {
                     Long holderCount = tuple.get(2, Long.class);
 
                     DeveloperType safeType =
-                            (devType != null) ? devType : DeveloperType.UNDEFINED;
+                            (devType != null) ? devType : DeveloperType.BASIC;
 
                     BigDecimal percentage = totalQuantity
                             .divide(totalSupply, 4, RoundingMode.HALF_UP)

--- a/src/main/java/team/avgmax/rabbit/user/controller/PersonalUserApiDocs.java
+++ b/src/main/java/team/avgmax/rabbit/user/controller/PersonalUserApiDocs.java
@@ -15,6 +15,7 @@ import team.avgmax.rabbit.user.dto.request.UpdatePersonalUserRequest;
 import team.avgmax.rabbit.user.dto.response.CarrotsResponse;
 import team.avgmax.rabbit.user.dto.response.FetchUserResponse;
 import team.avgmax.rabbit.user.dto.response.HoldBunniesResponse;
+import team.avgmax.rabbit.user.dto.response.HoldBunniesStatsResponse;
 import team.avgmax.rabbit.user.dto.response.PersonalUserResponse;
 import team.avgmax.rabbit.bunny.dto.response.OrderListResponse;
 
@@ -334,6 +335,62 @@ public interface PersonalUserApiDocs {
         )
     })
     ResponseEntity<HoldBunniesResponse> getMyHoldBunnies(
+        @Parameter(description = "JWT 토큰", hidden = true) Jwt jwt
+    );
+
+    @Operation(
+        summary = "보유 버니 통계 조회",
+        description = "현재 로그인한 사용자가 보유한 버니 통계 정보를 조회합니다."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "보유 버니 통계 조회 성공",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = HoldBunniesStatsResponse.class),
+                examples = @ExampleObject(
+                    value = """
+                    {
+                        "timestamp": "2025-09-20T23:45:15.50253",
+                        "total_market_cap": 1071613000,
+                        "position": {
+                            "frontend": 50.93,
+                            "backend": 49.07,
+                            "fullstack": 0,
+                            "top": {
+                                "type": "frontend",
+                                "total_market_cap": 545813000
+                            }
+                        },
+                        "developer_type": {
+                            "basic": 0,
+                            "growth": 14.98,
+                            "stable": 0,
+                            "value": 0,
+                            "popular": 48.1,
+                            "balance": 36.93,
+                            "top": {
+                                "type": "popular",
+                                "total_market_cap": 515400000
+                            }
+                        },
+                        "coin_type": {
+                            "a": 13.84,
+                            "b": 43.89,
+                            "c": 42.27,
+                            "top": {
+                                "type": "b",
+                                "total_market_cap": 470300000
+                            }
+                        }
+                    }
+                    """
+                )
+            )
+        )
+    })
+    ResponseEntity<HoldBunniesStatsResponse> getMyHoldBunniesStats(
         @Parameter(description = "JWT 토큰", hidden = true) Jwt jwt
     );
 

--- a/src/main/java/team/avgmax/rabbit/user/controller/PersonalUserController.java
+++ b/src/main/java/team/avgmax/rabbit/user/controller/PersonalUserController.java
@@ -18,6 +18,7 @@ import team.avgmax.rabbit.user.dto.request.UpdatePersonalUserRequest;
 import team.avgmax.rabbit.user.dto.response.CarrotsResponse;
 import team.avgmax.rabbit.user.dto.response.FetchUserResponse;
 import team.avgmax.rabbit.user.dto.response.HoldBunniesResponse;
+import team.avgmax.rabbit.user.dto.response.HoldBunniesStatsResponse;
 import team.avgmax.rabbit.user.dto.response.PersonalUserResponse;
 import team.avgmax.rabbit.bunny.dto.response.MatchListResponse;
 import team.avgmax.rabbit.bunny.dto.response.OrderListResponse;
@@ -36,7 +37,7 @@ public class PersonalUserController implements PersonalUserApiDocs {
     @GetMapping("/me")
     public ResponseEntity<FetchUserResponse> fetchPersonalUser(@AuthenticationPrincipal Jwt jwt) {
         String personalUserId = jwt.getSubject();
-        log.info("기본 정보 조회: {}", personalUserId);
+        log.info("기본 정보 조회: user-{}", personalUserId);
         
         return ResponseEntity.ok(personalUserService.fetchUserById(personalUserId));
     }
@@ -44,7 +45,7 @@ public class PersonalUserController implements PersonalUserApiDocs {
     @GetMapping("/me/info")
     public ResponseEntity<PersonalUserResponse> getMyInfo(@AuthenticationPrincipal Jwt jwt) {
         String personalUserId = jwt.getSubject();
-        log.info("나의 정보 조회: {}", personalUserId);
+        log.info("나의 정보 조회: user-{}", personalUserId);
         
         return ResponseEntity.ok(personalUserService.getUserById(personalUserId));
     }
@@ -52,14 +53,14 @@ public class PersonalUserController implements PersonalUserApiDocs {
     @PutMapping("/me/info")
     public ResponseEntity<PersonalUserResponse> updateMyInfo(@AuthenticationPrincipal Jwt jwt, @RequestBody UpdatePersonalUserRequest request) {
         String personalUserId = jwt.getSubject();
-        log.info("나의 정보 수정 : {}", personalUserId);
+        log.info("나의 정보 수정 : user-{}", personalUserId);
         return ResponseEntity.ok(personalUserService.updateUserById(personalUserId, request));
     }   
 
     @GetMapping("/me/carrots")
     public ResponseEntity<CarrotsResponse> getMyCarrots(@AuthenticationPrincipal Jwt jwt) {
         String personalUserId = jwt.getSubject();
-        log.info("보유 캐럿 조회: {}", personalUserId);
+        log.info("보유 캐럿 조회: user-{}", personalUserId);
 
         return ResponseEntity.ok(personalUserService.getCarrotsById(personalUserId));
     }   
@@ -67,15 +68,23 @@ public class PersonalUserController implements PersonalUserApiDocs {
     @GetMapping("/me/hold-bunnies")
     public ResponseEntity<HoldBunniesResponse> getMyHoldBunnies(@AuthenticationPrincipal Jwt jwt) {
         String personalUserId = jwt.getSubject();
-        log.info("보유 버니 조회: {}", personalUserId);
+        log.info("보유 버니 조회: user-{}", personalUserId);
 
         return ResponseEntity.ok(personalUserService.getBunniesById(personalUserId));
+    }
+
+    @GetMapping("/me/hold-bunnies/stats")
+    public ResponseEntity<HoldBunniesStatsResponse> getMyHoldBunniesStats(@AuthenticationPrincipal Jwt jwt) {
+        String personalUserId = jwt.getSubject();
+        log.info("보유 버니 통계 조회: user-{}", personalUserId);
+
+        return ResponseEntity.ok(personalUserService.getBunniesStatsById(personalUserId));
     }
 
     @GetMapping("/me/orders")
     public ResponseEntity<OrderListResponse> getMyOrders(@AuthenticationPrincipal Jwt jwt) {
         String personalUserId = jwt.getSubject();
-        log.info("미체결 주문 목록 조회: {}", personalUserId);  
+        log.info("미체결 주문 목록 조회: user-{}", personalUserId);  
 
         return ResponseEntity.ok(personalUserService.getOrdersById(personalUserId));
     }
@@ -83,7 +92,7 @@ public class PersonalUserController implements PersonalUserApiDocs {
     @GetMapping("/me/matches")
     public ResponseEntity<MatchListResponse> getMyMatches(@AuthenticationPrincipal Jwt jwt) {
         String personalUserId = jwt.getSubject();
-        log.info("체결 주문 목록 조회: {}", personalUserId);  
+        log.info("체결 주문 목록 조회: user-{}", personalUserId);  
 
         return ResponseEntity.ok(personalUserService.getMatchesById(personalUserId));
     }
@@ -91,7 +100,7 @@ public class PersonalUserController implements PersonalUserApiDocs {
     @PostMapping("/me/upload")
     public ResponseEntity<String> upload(@RequestParam("file") MultipartFile file, @AuthenticationPrincipal Jwt jwt) {
         String personalUserId = jwt.getSubject();
-        log.info("파일 업로드 요청: {}", personalUserId); 
+        log.info("파일 업로드 요청: user-{}", personalUserId); 
         String url = fileService.uploadFile(file, personalUserId);
         return ResponseEntity.ok(url); 
     }

--- a/src/main/java/team/avgmax/rabbit/user/dto/response/HoldBunniesStatsResponse.java
+++ b/src/main/java/team/avgmax/rabbit/user/dto/response/HoldBunniesStatsResponse.java
@@ -1,0 +1,169 @@
+package team.avgmax.rabbit.user.dto.response;
+
+import java.util.List;
+import java.util.Map;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDateTime;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import lombok.Builder;
+import team.avgmax.rabbit.bunny.entity.enums.BunnyType;
+import team.avgmax.rabbit.bunny.entity.enums.DeveloperType;
+import team.avgmax.rabbit.user.entity.HoldBunny;
+import team.avgmax.rabbit.user.entity.enums.Position;
+
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record HoldBunniesStatsResponse(
+    LocalDateTime timestamp,
+    BigDecimal totalMarketCap,
+    PositionStats position,
+    DeveloperTypeStats developerType,
+    CoinTypeStats coinType
+) {
+    
+    private static <T extends Enum<T>> TopStats findTopField(List<HoldBunny> holdBunnies, Class<T> enumClass, Function<HoldBunny, T> enumExtractor) {
+        return holdBunnies.stream()
+            .collect(Collectors.groupingBy(
+                enumExtractor,
+                Collectors.reducing(
+                    BigDecimal.ZERO,
+                    holdBunny -> holdBunny.getBunny().getMarketCap(),
+                    BigDecimal::add
+                )
+            ))
+            .entrySet().stream()
+            .max(Map.Entry.comparingByValue())
+            .map(entry -> new TopStats(
+                entry.getKey().name().toLowerCase(),
+                entry.getValue()
+            ))
+            .orElse(new TopStats("unknown", BigDecimal.ZERO));
+    }
+    
+    private static BigDecimal calculateMarketCapSum(List<HoldBunny> holdBunnies, Predicate<HoldBunny> filter) {
+        return holdBunnies.stream()
+            .filter(filter)
+            .map(holdBunny -> holdBunny.getBunny().getMarketCap())
+            .reduce(BigDecimal.ZERO, BigDecimal::add);
+    }
+    
+    private static BigDecimal calculateTotalMarketCap(List<HoldBunny> holdBunnies) {
+        return calculateMarketCapSum(holdBunnies, holdBunny -> true);
+    }
+    
+    private static double calculateRatio(BigDecimal part, BigDecimal total) {
+        return total.compareTo(BigDecimal.ZERO) == 0 ? 0.0 : 
+            part.divide(total, 4, RoundingMode.HALF_UP).multiply(BigDecimal.valueOf(100)).doubleValue();
+    }
+
+    @Builder
+    public static record PositionStats(
+        double frontend,
+        double backend,
+        double fullstack,
+        TopStats top
+    ) {
+        public static PositionStats from(List<HoldBunny> holdBunnies, BigDecimal totalMarketCap) {
+            BigDecimal frontendMarketCap = calculateMarketCapSum(holdBunnies, 
+                holdBunny -> holdBunny.getBunny().getUser().getPosition() == Position.FRONTEND);
+            BigDecimal backendMarketCap = calculateMarketCapSum(holdBunnies, 
+                holdBunny -> holdBunny.getBunny().getUser().getPosition() == Position.BACKEND);
+            BigDecimal fullstackMarketCap = calculateMarketCapSum(holdBunnies, 
+                holdBunny -> holdBunny.getBunny().getUser().getPosition() == Position.FULLSTACK);
+            
+            return PositionStats.builder()
+                .frontend(calculateRatio(frontendMarketCap, totalMarketCap))
+                .backend(calculateRatio(backendMarketCap, totalMarketCap))
+                .fullstack(calculateRatio(fullstackMarketCap, totalMarketCap))
+                .top(findTopField(holdBunnies, Position.class, holdBunny -> holdBunny.getBunny().getUser().getPosition()))
+                .build();
+        }
+    }
+
+    @Builder
+    public static record DeveloperTypeStats(
+        double basic,
+        double growth,
+        double stable,
+        double value,
+        double popular,
+        double balance,
+        TopStats top
+    ) {
+        public static DeveloperTypeStats from(List<HoldBunny> holdBunnies, BigDecimal totalMarketCap) {
+            
+            BigDecimal basicMarketCap = calculateMarketCapSum(holdBunnies, 
+                holdBunny -> holdBunny.getBunny().getDeveloperType() == DeveloperType.BASIC);
+            BigDecimal growthMarketCap = calculateMarketCapSum(holdBunnies, 
+                holdBunny -> holdBunny.getBunny().getDeveloperType() == DeveloperType.GROWTH);
+            BigDecimal stableMarketCap = calculateMarketCapSum(holdBunnies, 
+                holdBunny -> holdBunny.getBunny().getDeveloperType() == DeveloperType.STABLE);
+            BigDecimal valueMarketCap = calculateMarketCapSum(holdBunnies, 
+                holdBunny -> holdBunny.getBunny().getDeveloperType() == DeveloperType.VALUE);
+            BigDecimal popularMarketCap = calculateMarketCapSum(holdBunnies, 
+                holdBunny -> holdBunny.getBunny().getDeveloperType() == DeveloperType.POPULAR);
+            BigDecimal balanceMarketCap = calculateMarketCapSum(holdBunnies, 
+                holdBunny -> holdBunny.getBunny().getDeveloperType() == DeveloperType.BALANCE);
+            
+            return DeveloperTypeStats.builder()
+                .basic(calculateRatio(basicMarketCap, totalMarketCap))
+                .growth(calculateRatio(growthMarketCap, totalMarketCap))
+                .stable(calculateRatio(stableMarketCap, totalMarketCap))
+                .value(calculateRatio(valueMarketCap, totalMarketCap))
+                .popular(calculateRatio(popularMarketCap, totalMarketCap))
+                .balance(calculateRatio(balanceMarketCap, totalMarketCap))
+                .top(findTopField(holdBunnies, DeveloperType.class, holdBunny -> holdBunny.getBunny().getDeveloperType()))
+                .build();
+        }
+    }
+
+    @Builder
+    public static record CoinTypeStats(
+        double a,
+        double b,
+        double c,
+        TopStats top
+    ) {
+        public static CoinTypeStats from(List<HoldBunny> holdBunnies, BigDecimal totalMarketCap) {
+            
+            
+            BigDecimal aMarketCap = calculateMarketCapSum(holdBunnies, 
+                holdBunny -> holdBunny.getBunny().getBunnyType() == BunnyType.A);
+            BigDecimal bMarketCap = calculateMarketCapSum(holdBunnies, 
+                holdBunny -> holdBunny.getBunny().getBunnyType() == BunnyType.B);
+            BigDecimal cMarketCap = calculateMarketCapSum(holdBunnies, 
+                holdBunny -> holdBunny.getBunny().getBunnyType() == BunnyType.C);
+
+            return CoinTypeStats.builder()
+                .a(calculateRatio(aMarketCap, totalMarketCap))
+                .b(calculateRatio(bMarketCap, totalMarketCap))
+                .c(calculateRatio(cMarketCap, totalMarketCap))
+                .top(findTopField(holdBunnies, BunnyType.class, holdBunny -> holdBunny.getBunny().getBunnyType()))
+                .build();
+        }
+    }
+    
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public static record TopStats(
+        String type,
+        BigDecimal totalMarketCap
+    ) {}
+
+    public static HoldBunniesStatsResponse from(List<HoldBunny> holdBunnies) {
+        BigDecimal totalMarketCap = calculateTotalMarketCap(holdBunnies);
+        return HoldBunniesStatsResponse.builder()
+                .timestamp(LocalDateTime.now())
+                .totalMarketCap(totalMarketCap)
+                .position(PositionStats.from(holdBunnies, totalMarketCap))
+                .developerType(DeveloperTypeStats.from(holdBunnies, totalMarketCap))
+                .coinType(CoinTypeStats.from(holdBunnies, totalMarketCap))
+                .build();
+    }
+}

--- a/src/main/java/team/avgmax/rabbit/user/repository/HoldBunnyRepository.java
+++ b/src/main/java/team/avgmax/rabbit/user/repository/HoldBunnyRepository.java
@@ -11,8 +11,11 @@ import team.avgmax.rabbit.user.entity.PersonalUser;
 import team.avgmax.rabbit.user.repository.custom.HoldBunnyRepositoryCustom;
 
 import java.util.Optional;
+import java.util.List;
 
 public interface HoldBunnyRepository extends JpaRepository<HoldBunny, String>, HoldBunnyRepositoryCustom {
+
+    List<HoldBunny> findByHolder(PersonalUser holder);
 
     Optional<HoldBunny> findByHolderAndBunny(PersonalUser holder, Bunny bunny);
 

--- a/src/main/java/team/avgmax/rabbit/user/service/PersonalUserService.java
+++ b/src/main/java/team/avgmax/rabbit/user/service/PersonalUserService.java
@@ -15,6 +15,7 @@ import team.avgmax.rabbit.user.dto.request.UpdatePersonalUserRequest;
 import team.avgmax.rabbit.user.dto.response.CarrotsResponse;
 import team.avgmax.rabbit.user.dto.response.FetchUserResponse;
 import team.avgmax.rabbit.user.dto.response.HoldBunniesResponse;
+import team.avgmax.rabbit.user.dto.response.HoldBunniesStatsResponse;
 import team.avgmax.rabbit.user.dto.response.PersonalUserResponse;
 import team.avgmax.rabbit.user.entity.PersonalUser;
 import team.avgmax.rabbit.user.entity.enums.Role;
@@ -25,10 +26,11 @@ import team.avgmax.rabbit.user.entity.enums.ProviderType;
 import team.avgmax.rabbit.bunny.entity.Bunny;
 import team.avgmax.rabbit.bunny.entity.Match;
 import team.avgmax.rabbit.bunny.repository.BunnyRepository;
+import team.avgmax.rabbit.bunny.repository.OrderRepository;
+import team.avgmax.rabbit.user.entity.HoldBunny;
+import team.avgmax.rabbit.user.repository.HoldBunnyRepository;
 import team.avgmax.rabbit.user.repository.PersonalUserRepository;
-import team.avgmax.rabbit.user.repository.custom.HoldBunnyRepositoryCustomImpl;
-import team.avgmax.rabbit.bunny.repository.custom.MatchRepositoryCustomImpl;
-import team.avgmax.rabbit.bunny.repository.custom.OrderRepositoryCustomImpl;
+import team.avgmax.rabbit.bunny.repository.MatchRepository;
 
 @Service
 @RequiredArgsConstructor
@@ -36,9 +38,9 @@ public class PersonalUserService {
     private final ChatClientService chatClientService;
 
     private final PersonalUserRepository personalUserRepository;
-    private final OrderRepositoryCustomImpl orderRepositoryCustom;
-    private final MatchRepositoryCustomImpl matchRepositoryCustom;
-    private final HoldBunnyRepositoryCustomImpl holdBunnyRepositoryCustom;
+    private final OrderRepository orderRepository;
+    private final MatchRepository matchRepository;
+    private final HoldBunnyRepository holdBunnyRepository;
     private final BunnyRepository bunnyRepository;
 
     @Transactional
@@ -104,12 +106,20 @@ public class PersonalUserService {
 
     @Transactional(readOnly = true)
     public HoldBunniesResponse getBunniesById(String personalUserId) {
-        return holdBunnyRepositoryCustom.findHoldBunniesByUserId(personalUserId);
+        return holdBunnyRepository.findHoldBunniesByUserId(personalUserId);
+    }
+
+    @Transactional(readOnly = true)
+    public HoldBunniesStatsResponse getBunniesStatsById(String personalUserId) {
+        PersonalUser personalUser = findPersonalUserById(personalUserId);
+        List<HoldBunny> holdBunnies = holdBunnyRepository.findByHolder(personalUser);
+
+        return HoldBunniesStatsResponse.from(holdBunnies);
     }
 
     @Transactional(readOnly = true)
     public OrderListResponse getOrdersById(String personalUserId) {
-        return orderRepositoryCustom.findOrdersByUserId(personalUserId);
+        return orderRepository.findOrdersByUserId(personalUserId);
     }
 
     @Transactional(readOnly = true)
@@ -120,7 +130,7 @@ public class PersonalUserService {
 
     @Transactional(readOnly = true)
     public MatchListResponse getMatchesById(String personalUserId){
-        List<Match> matches = matchRepositoryCustom.findMatchesByUserId(personalUserId);
+        List<Match> matches = matchRepository.findMatchesByUserId(personalUserId);
         List<MatchResponse> matchResponses = matches.stream()
             .map(match -> MatchResponse.from(match, personalUserId))
             .toList();


### PR DESCRIPTION
## 📌 작업 개요
- 보유 버니 통계 조회 API 구현

## ✅ 작업 상세
- 보유 버니 통계 조회 API를 구현했습니다. 스웨거에 예시도 넣었습니다.
- PersonalUserService에서 Custom 레포지토리 대신 이를 상속받은 기본 레포지토리를 의존하도록 해서 확장성읖 높였습니다.

## 🎫 관련 이슈
- [RABBIT-80](https://dssw5.atlassian.net/browse/RABBIT-80)

## 🎬 참고 이미지
<img width="1396" height="852" alt="image" src="https://github.com/user-attachments/assets/4c94a5ca-7389-49b3-8f59-e67c45960833" />

## 📎 기타
- 개발자 유형 '기본형'을 버니 미발행자와 혼동을 방지하기 위해 UNDEFINED -> BASIC 이름 수정했습니다.
    - (DB에 충돌이 있을 것 같아서 넣어두려고 했는데 지금 넷버드가 안켜져요 ㅠㅠ)