### PR TITLE
feat: [RABBIT-88] 지표 계산 로직 구현

### DIFF
--- a/src/main/java/team/avgmax/rabbit/bunny/dto/response/FetchBunnyResponse.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/dto/response/FetchBunnyResponse.java
@@ -28,7 +28,7 @@ public class FetchBunnyResponse {
     private DeveloperType developerType;
     private BunnyType bunnyType;
     private Position position;
-    private BigDecimal reliability; // 신뢰도
+    private int reliability; // 신뢰도
 
     // 가격 정보
     private BigDecimal currentPrice;

--- a/src/main/java/team/avgmax/rabbit/bunny/dto/response/MyBunnyResponse.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/dto/response/MyBunnyResponse.java
@@ -39,7 +39,7 @@ public class MyBunnyResponse {
     private List<DailyPriceData> priceHistory;
 
     // 요구사항 3: 시장 신뢰도
-    private BigDecimal reliability;
+    private int reliability;
 
     // 요구사항 4: 시가총액, 현재가, 종가
     private BigDecimal currentPrice;

--- a/src/main/java/team/avgmax/rabbit/bunny/entity/Bunny.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/entity/Bunny.java
@@ -12,6 +12,8 @@ import team.avgmax.rabbit.funding.entity.FundBunny;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.IntStream;
+import java.time.LocalDateTime;
 
 import team.avgmax.rabbit.user.entity.PersonalUser;
 
@@ -40,7 +42,8 @@ public class Bunny extends BaseTime {
     @Enumerated(EnumType.STRING)
     private BunnyType bunnyType;
 
-    private BigDecimal reliability;
+    @Builder.Default
+    private int reliability = 10;
 
     private BigDecimal currentPrice; 
 
@@ -48,15 +51,20 @@ public class Bunny extends BaseTime {
 
     private BigDecimal marketCap;
 
-    private int growth;
+    @Builder.Default
+    private int growth = 10;
 
-    private int stability;
+    @Builder.Default
+    private int stability = 10;
 
-    private int value;
+    @Builder.Default
+    private int value = 10;
 
-    private int popularity;
+    @Builder.Default
+    private int popularity = 10;
 
-    private int balance;
+    @Builder.Default
+    private int balance = 10;
     
     private String aiReview;
 
@@ -75,7 +83,6 @@ public class Bunny extends BaseTime {
                 .bunnyName(fundBunny.getBunnyName())
                 .developerType(DeveloperType.BASIC)
                 .bunnyType(fundBunny.getType())
-                .reliability(BigDecimal.ZERO) // 추후 계산 로직 추가
                 .currentPrice(fundBunny.getType().getPrice())
                 .closingPrice(fundBunny.getType().getPrice())
                 .marketCap(fundBunny.getType().getMarketCap())
@@ -90,5 +97,57 @@ public class Bunny extends BaseTime {
 
     public void subtractLikeCount() {
         this.likeCount--;
+    }
+
+    public void updateReliability(double reliability) {
+        this.reliability = (int) reliability;
+    }
+    
+    public void updateGrowth(double growth) {
+        this.growth = (int) growth;
+        updateDeveloperType();
+    }
+    
+    public void updateStability(double stability) {
+        this.stability = (int) stability;
+        updateDeveloperType();
+    }
+    
+    public void updateValue(double value) {
+        this.value = (int) value;
+        updateDeveloperType();
+    }
+    
+    public void updatePopularity(double popularity) {
+        this.popularity = (int) popularity;
+        updateDeveloperType();
+    }
+    
+    public void updateBalance(double balance) {
+        this.balance = (int) balance;
+        updateDeveloperType();
+    }
+
+    private void updateDeveloperType() {
+        // 생성 후 7일 이내는 BASIC 유지
+        if (this.getCreatedAt().isAfter(LocalDateTime.now().minusDays(7))) {
+            this.developerType = DeveloperType.BASIC;
+            return;
+        }
+
+        int maxScore = IntStream.of(growth, stability, value, popularity, balance).max().orElseThrow();
+        if (maxScore == growth) {
+            this.developerType = DeveloperType.GROWTH;
+        } else if (maxScore == stability) {
+            this.developerType = DeveloperType.STABLE;
+        } else if (maxScore == value) {
+            this.developerType = DeveloperType.VALUE;
+        } else if (maxScore == popularity) {
+            this.developerType = DeveloperType.POPULAR;
+        } else if (maxScore == balance) {
+            this.developerType = DeveloperType.BALANCE;
+        } else {
+            this.developerType = DeveloperType.BASIC; // 기본값
+        }
     }
 }

--- a/src/main/java/team/avgmax/rabbit/bunny/repository/BunnyRepository.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/repository/BunnyRepository.java
@@ -23,4 +23,5 @@ public interface BunnyRepository extends JpaRepository<Bunny, String>, BunnyRepo
 
     Optional<Bunny> findByUserId(String userId);
 
+    boolean existsByUserId(String userId);
 }

--- a/src/main/java/team/avgmax/rabbit/bunny/repository/custom/BunnyHistoryRepositoryCustom.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/repository/custom/BunnyHistoryRepositoryCustom.java
@@ -1,6 +1,7 @@
 package team.avgmax.rabbit.bunny.repository.custom;
 
 import team.avgmax.rabbit.bunny.dto.response.ChartDataPoint;
+import team.avgmax.rabbit.bunny.entity.BunnyHistory;
 import team.avgmax.rabbit.bunny.entity.enums.ChartInterval;
 
 import java.util.List;
@@ -8,4 +9,6 @@ import java.util.List;
 public interface BunnyHistoryRepositoryCustom {
 
     List<ChartDataPoint> findChartData(String bunnyId, ChartInterval interval);
+    
+    List<BunnyHistory> findRecentByBunnyIdOrderByDateAsc(String bunnyId, int days);
 }

--- a/src/main/java/team/avgmax/rabbit/bunny/repository/custom/BunnyHistoryRepositoryCustomImpl.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/repository/custom/BunnyHistoryRepositoryCustomImpl.java
@@ -7,10 +7,12 @@ import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import team.avgmax.rabbit.bunny.dto.response.ChartDataPoint;
+import team.avgmax.rabbit.bunny.entity.BunnyHistory;
 import team.avgmax.rabbit.bunny.entity.QBunnyHistory;
 import team.avgmax.rabbit.bunny.entity.enums.ChartInterval;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 
@@ -145,6 +147,22 @@ public class BunnyHistoryRepositoryCustomImpl implements BunnyHistoryRepositoryC
                 .where(bunnyHistory.bunnyId.eq(bunnyId))
                 .groupBy(monthKey)
                 .orderBy(monthKey.asc())
+                .fetch();
+    }
+    
+    @Override
+    public List<BunnyHistory> findRecentByBunnyIdOrderByDateAsc(String bunnyId, int days) {
+        if (bunnyId == null || days <= 0) return Collections.emptyList();
+        
+        LocalDate targetDate = LocalDate.now().minusDays(days);
+        
+        return queryFactory
+                .selectFrom(bunnyHistory)
+                .where(
+                        bunnyHistory.bunnyId.eq(bunnyId),
+                        bunnyHistory.date.goe(targetDate)
+                )
+                .orderBy(bunnyHistory.date.asc())
                 .fetch();
     }
 }

--- a/src/main/java/team/avgmax/rabbit/bunny/service/BunnyIndicatorService.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/service/BunnyIndicatorService.java
@@ -1,0 +1,350 @@
+package team.avgmax.rabbit.bunny.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import team.avgmax.rabbit.bunny.entity.Bunny;
+import team.avgmax.rabbit.bunny.entity.BunnyHistory;
+import team.avgmax.rabbit.bunny.repository.BunnyHistoryRepository;
+import team.avgmax.rabbit.user.entity.Career;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class BunnyIndicatorService {
+    
+    private final BunnyHistoryRepository bunnyHistoryRepository;
+
+    // ==================== Public Update Methods ====================
+    
+    public void updateBunnyReliability(Bunny bunny) {
+        double reliability = calculateReliability(bunny);
+        bunny.updateReliability(reliability);
+    }
+    
+    public void updateBunnyGrowth(Bunny bunny) {
+        double growth = calculateAnnualizedGrowthRate(bunny.getId());
+        bunny.updateGrowth(growth);
+    }
+    
+    public void updateBunnyStability(Bunny bunny) {
+        double stability = calculateVolatility30dPct(bunny.getId());
+        bunny.updateStability(stability);
+    }
+    
+    public void updateBunnyValue(Bunny bunny) {
+        double value = calculateValueScore(bunny);
+        bunny.updateValue(value);
+    }
+    
+    public void updateBunnyPopularity(Bunny bunny) {
+        double popularity = calculatePopularityScore(bunny);
+        bunny.updatePopularity(popularity);
+    }
+    
+    public void updateBunnyBalance(Bunny bunny) {
+        double balance = calculateBalanceScore(bunny);
+        bunny.updateBalance(balance);
+    }
+
+    // ==================== Reliability Calculation ====================
+    
+    private double calculateReliability(Bunny bunny) {
+        double skillScore = calculateSkillScore(bunny);
+        double marketScore = calculateMarketScore(bunny);
+        double reputationScore = calculateReputationScore(bunny);
+        
+        double total = skillScore * 0.4 + marketScore * 0.3 + reputationScore * 0.3;
+        return Math.max(0, Math.min(100, Math.round(total)));
+    }
+    
+    private double calculateSkillScore(Bunny bunny) {
+        double score = 0;
+        
+        // 경력 점수: 0~10년을 0~40점으로 선형 변환
+        double years = calculateCareerYears(bunny);
+        double careerScore = Math.min(40, years / 10.0 * 40);
+        score += careerScore;
+
+        // 기술 스택 점수: 0~5개를 0~5점으로 선형 변환
+        int techCount = bunny.getUser().getSkill().size();
+        double techScore = Math.min(5, techCount / 5.0 * 5);
+        score += techScore;
+        
+        // 자격증 점수: 0~3개를 0~5점으로 선형 변환
+        int certCount = bunny.getUser().getCertification().size();
+        double certScore = Math.min(5, certCount / 3.0 * 5);
+        score += certScore;
+
+        return score;
+    }
+    
+    private double calculateMarketScore(Bunny bunny) {
+        double score = 0;
+        double growth = bunny.getGrowth();
+        double volatility = bunny.getStability();
+        double liquidity = bunny.getBalance();
+
+        // 성장률 점수: 0~100%를 0~30점으로 선형 변환
+        double growthScore = Math.min(30, Math.max(0, growth) / 100.0 * 30);
+        score += growthScore;
+
+        // 변동성 점수: 0~50%를 30~0점으로 선형 변환 (낮을수록 좋음)
+        double volatilityScore = Math.max(0, 30 - (Math.max(0, volatility) / 50.0 * 30));
+        score += volatilityScore;
+
+        // 유동성 점수: 0~100%를 0~10점으로 선형 변환
+        double liquidityScore = Math.min(10, Math.max(0, liquidity) / 100.0 * 10);
+        score += liquidityScore;
+
+        return score;
+    }
+    
+    private double calculateReputationScore(Bunny bunny) {
+        double score = 0;
+
+        // 인증 점수: 증명서 비율을 0~10점으로 선형 변환
+        long totalItems = bunny.getUser().getCareer().size() + bunny.getUser().getCertification().size();
+        if (totalItems > 0) {
+            long verifiedCount = bunny.getUser().getCareer().stream()
+                    .mapToLong(c -> c.getCertificateUrl() != null && !c.getCertificateUrl().isBlank() ? 1 : 0)
+                    .sum() +
+                    bunny.getUser().getCertification().stream()
+                    .mapToLong(c -> c.getCertificateUrl() != null && !c.getCertificateUrl().isBlank() ? 1 : 0)
+                    .sum();
+            
+            double verificationScore = (double) verifiedCount / totalItems * 10;
+            score += verificationScore;
+        }
+
+        // 좋아요 점수: 0~30개를 0~10점으로 선형 변환
+        long likes = bunny.getLikeCount();
+        double likeScore = Math.min(10, likes / 30.0 * 10);
+        score += likeScore;
+
+        // 업데이트 점수: 0~365일을 10~0점으로 선형 변환 (최신일수록 높음)
+        long daysSinceUpdate = ChronoUnit.DAYS.between(bunny.getUser().getSpecUpdatedAt().toLocalDate(), LocalDate.now());
+        double updateScore = Math.max(0, 10 - (daysSinceUpdate / 365.0 * 10));
+        score += updateScore;
+
+        return score;
+    }
+    
+    private double calculateCareerYears(Bunny bunny) {
+        List<Career> careers = bunny.getUser().getCareer();
+        if (careers.isEmpty()) return 0.0;
+        
+        long totalDays = calculateMergedCareerDays(careers);
+        return totalDays / 365.0;
+    }
+    
+    private long calculateMergedCareerDays(List<Career> careers) {
+        List<LocalDate[]> periods = careers.stream()
+                .map(c -> new LocalDate[]{c.getStartDate(), c.getEndDate() != null ? c.getEndDate() : LocalDate.now()})
+                .sorted(Comparator.comparing(arr -> arr[0]))
+                .toList();
+
+        long totalDays = 0;
+        LocalDate currentStart = null, currentEnd = null;
+
+        for (LocalDate[] period : periods) {
+            if (currentStart == null) {
+                currentStart = period[0];
+                currentEnd = period[1];
+            } else if (!period[0].isAfter(currentEnd)) {
+                if (period[1].isAfter(currentEnd)) currentEnd = period[1];
+            } else {
+                totalDays += ChronoUnit.DAYS.between(currentStart, currentEnd);
+                currentStart = period[0];
+                currentEnd = period[1];
+            }
+        }
+
+        if (currentStart != null) totalDays += ChronoUnit.DAYS.between(currentStart, currentEnd);
+        return totalDays;
+    }
+
+    // ==================== Growth Calculation ====================
+    
+    private double calculateAnnualizedGrowthRate(String bunnyId) {
+        List<BunnyHistory> histories = bunnyHistoryRepository.findAllByBunnyIdOrderByDateAsc(bunnyId);
+        
+        if (histories.size() < 2) return 0.0;
+        
+        BunnyHistory first = histories.get(0);
+        BunnyHistory last = histories.get(histories.size() - 1);
+        
+        BigDecimal startValue = first.getClosingPrice();
+        BigDecimal endValue = last.getClosingPrice();
+        
+        if (startValue == null || endValue == null || startValue.compareTo(BigDecimal.ZERO) == 0) {
+            return 0.0;
+        }
+        
+        long days = ChronoUnit.DAYS.between(first.getDate(), last.getDate());
+        if (days <= 0) return 0.0;
+        
+        double ratio = endValue.doubleValue() / startValue.doubleValue();
+        double annualized = Math.pow(ratio, 365.0 / days) - 1.0;
+        
+        return annualized * 100;
+    }
+
+    // ==================== Stability Calculation ====================
+    
+    private double calculateVolatility30dPct(String bunnyId) {
+        List<BunnyHistory> histories = bunnyHistoryRepository.findRecentByBunnyIdOrderByDateAsc(bunnyId, 31);
+        
+        if (histories.size() < 2) return 0.0;
+        
+        List<Double> returns = new ArrayList<>();
+        for (int i = 1; i < histories.size(); i++) {
+            BigDecimal prev = histories.get(i - 1).getClosingPrice();
+            BigDecimal curr = histories.get(i).getClosingPrice();
+            
+            if (prev == null || curr == null || prev.compareTo(BigDecimal.ZERO) == 0) {
+                continue;
+            }
+            
+            double r = Math.log(curr.doubleValue() / prev.doubleValue());
+            returns.add(r);
+        }
+        
+        if (returns.isEmpty()) return 0.0;
+        
+        double mean = returns.stream().mapToDouble(Double::doubleValue).average().orElse(0.0);
+        double variance = returns.stream()
+                .mapToDouble(r -> Math.pow(r - mean, 2))
+                .sum() / returns.size();
+        double stdDev = Math.sqrt(variance);
+        
+        return stdDev * 100;
+    }
+
+    // ==================== Value Calculation ====================
+    
+    private double calculateValueScore(Bunny bunny) {
+        double score = 0;
+        
+        // 시가총액 점수: 0~200억을 0~50점으로 선형 변환
+        BigDecimal marketCap = bunny.getMarketCap();
+        if (marketCap != null) {
+            double marketCapScore = Math.min(50, marketCap.doubleValue() / 20_000_000_000.0 * 50);
+            score += marketCapScore;
+        }
+        
+        // 신뢰도 점수: 0~100점을 0~50점으로 선형 변환
+        double reliability = bunny.getReliability();
+        double reliabilityScore = reliability / 100.0 * 50;
+        score += reliabilityScore;
+        
+        return Math.min(100, score);
+    }
+
+    // ==================== Popularity Calculation ====================
+    
+    private double calculatePopularityScore(Bunny bunny) {
+        double score = 0;
+        
+        double tradingScore = calculateTradingVolumeScore(bunny);
+        score += tradingScore;
+        
+        double likeScore = calculateLikeCountScore(bunny.getLikeCount());
+        score += likeScore;
+        
+        return Math.min(100, score);
+    }
+    
+    private double calculateTradingVolumeScore(Bunny bunny) {
+        List<BunnyHistory> histories = bunnyHistoryRepository.findRecentByBunnyIdOrderByDateAsc(bunny.getId(), 30);
+        
+        if (histories.isEmpty()) return 0.0;
+        
+        double totalVolume = histories.stream()
+                .mapToDouble(h -> {
+                    BigDecimal tradeQty = h.getTradeQuantity();
+                    return (tradeQty != null && tradeQty.compareTo(BigDecimal.ZERO) > 0) 
+                            ? tradeQty.doubleValue() 
+                            : 0.0;
+                })
+                .sum();
+        
+        double avgDailyVolume = totalVolume / histories.size();
+        
+        // BunnyType별 총 발행량에 따른 거래량 비율 계산
+        BigDecimal totalSupply = bunny.getBunnyType().getTotalSupply();
+        double tradingRatio = avgDailyVolume / totalSupply.doubleValue();
+        
+        // 거래량 비율을 0~60점으로 선형 변환 (최대 2% 기준)
+        return Math.min(60, tradingRatio / 0.02 * 60);
+    }
+    
+    private double calculateLikeCountScore(long likeCount) {
+        return Math.min(40, likeCount / 100.0 * 40);
+    }
+
+    // ==================== Balance Calculation ====================
+    
+    private double calculateBalanceScore(Bunny bunny) {
+        double score = 0;
+        
+        double marketCapScore = calculateMarketCapBalanceScore(bunny.getMarketCap());
+        score += marketCapScore;
+        
+        double growthScore = calculateGrowthBalanceScore(bunny.getGrowth());
+        score += growthScore;
+        
+        double stabilityScore = calculateStabilityBalanceScore(bunny.getStability());
+        score += stabilityScore;
+        
+        return Math.min(100, score);
+    }
+    
+    private double calculateMarketCapBalanceScore(BigDecimal marketCap) {
+        if (marketCap == null) return 0.0;
+        
+        double cap = marketCap.doubleValue();
+        
+        // 이상적인 가격대: 10억 ~ 50억에서 최대 점수
+        if (cap >= 1_000_000_000 && cap <= 5_000_000_000.0) {
+            return 40.0;
+        } else if (cap < 1_000_000_000) {
+            // 0~10억: 선형 증가
+            return cap / 1_000_000_000 * 40;
+        } else {
+            // 50억 초과: 선형 감소 (최대 100억까지)
+            return Math.max(0, 40 - (cap - 5_000_000_000.0) / 5_000_000_000.0 * 40);
+        }
+    }
+    
+    private double calculateGrowthBalanceScore(double growth) {
+        // 이상적인 성장률: 10% ~ 30%에서 최대 점수
+        if (growth >= 10 && growth <= 30) {
+            return 30.0;
+        } else if (growth < 10) {
+            // 0~10%: 선형 증가
+            return Math.max(0, growth / 10.0 * 30);
+        } else {
+            // 30% 초과: 선형 감소 (최대 60%까지)
+            return Math.max(0, 30 - (growth - 30) / 30.0 * 30);
+        }
+    }
+    
+    private double calculateStabilityBalanceScore(double stability) {
+        // 이상적인 변동성: 5% ~ 15%에서 최대 점수
+        if (stability >= 5 && stability <= 15) {
+            return 30.0;
+        } else if (stability < 5) {
+            // 0~5%: 선형 증가
+            return Math.max(0, stability / 5.0 * 30);
+        } else {
+            // 15% 초과: 선형 감소 (최대 30%까지)
+            return Math.max(0, 30 - (stability - 15) / 15.0 * 30);
+        }
+    }
+}

--- a/src/main/java/team/avgmax/rabbit/bunny/service/BunnyService.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/service/BunnyService.java
@@ -70,6 +70,7 @@ public class BunnyService {
     private final CorporationUserRepository corporationUserRepository;
     private final OrderBookAssembler orderBookAssembler;
     private final OrderBookPublisher orderBookPublisher;
+    private final BunnyIndicatorService bunnyIndicatorService;
 
     // 버니 목록 조회
     @Transactional(readOnly = true) // 읽기 전용
@@ -132,7 +133,7 @@ public class BunnyService {
                 .todayTime(LocalDate.now())
                 .monthlyGrowthRates(monthlyGrowRate)
                 .priceHistory(priceHistory)
-                .reliability(myBunny.getReliability()) // 추후 계산 로직 구상 시 구현
+                .reliability(myBunny.getReliability())
                 .currentPrice(myBunny.getCurrentPrice())
                 .closingPrice(myBunny.getClosingPrice())
                 .marketCap(myBunny.getMarketCap())
@@ -195,6 +196,9 @@ public class BunnyService {
             badgeRepository.save(Badge.create(bunny.getId(), userId, corporationUser.getCorporationName()));
         }
         bunny.addLikeCount();
+        bunnyIndicatorService.updateBunnyReliability(bunny);
+        bunnyIndicatorService.updateBunnyValue(bunny);
+        bunnyIndicatorService.updateBunnyPopularity(bunny);
     }
 
     // 좋아요 취소
@@ -207,6 +211,9 @@ public class BunnyService {
             return;
         }
         bunny.subtractLikeCount();
+        bunnyIndicatorService.updateBunnyReliability(bunny);
+        bunnyIndicatorService.updateBunnyValue(bunny);
+        bunnyIndicatorService.updateBunnyPopularity(bunny);
     }
 
     private Bunny findBunnyByName(String bunnyName) {

--- a/src/main/java/team/avgmax/rabbit/global/entity/BaseTime.java
+++ b/src/main/java/team/avgmax/rabbit/global/entity/BaseTime.java
@@ -22,8 +22,8 @@ import java.time.LocalDateTime;
 public class BaseTime {
 
     @CreatedDate
-    private LocalDateTime createdAt;
+    protected LocalDateTime createdAt;
 
     @LastModifiedDate
-    private LocalDateTime updatedAt;
+    protected LocalDateTime updatedAt;
 }

--- a/src/main/java/team/avgmax/rabbit/user/entity/PersonalUser.java
+++ b/src/main/java/team/avgmax/rabbit/user/entity/PersonalUser.java
@@ -2,6 +2,7 @@ package team.avgmax.rabbit.user.entity;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -20,6 +21,7 @@ import team.avgmax.rabbit.user.dto.request.UpdatePersonalUserRequest;
 import team.avgmax.rabbit.user.entity.enums.Position;
 import team.avgmax.rabbit.user.exception.UserException;
 import team.avgmax.rabbit.user.exception.UserError;
+import team.avgmax.rabbit.user.entity.enums.Role;
 
 @Entity
 @Getter
@@ -77,6 +79,8 @@ public class PersonalUser extends User {
 
     String aiReview;
 
+    LocalDateTime specUpdatedAt;
+
     // === 연관관계 편의 메서드 ===
     public void addProvider(UserProvider provider) {
         providers.add(provider);
@@ -94,8 +98,14 @@ public class PersonalUser extends User {
         this.carrot = this.carrot.subtract(carrot);
     }
 
+    public void updateRoleToBunny() {
+        this.role = Role.ROLE_BUNNY;
+    }
+
     public void updatePersonalUser(UpdatePersonalUserRequest request) {
-        updateUser(request.name(), request.image(), request.email());
+        this.name = request.name();
+        this.image = request.image();
+        this.email = request.email();
         this.birthdate = request.birthdate();
         this.resume = request.resume();
         this.portfolio = request.portfolio();
@@ -130,6 +140,8 @@ public class PersonalUser extends User {
         this.education.addAll(request.education().stream()
             .map(Education::create)
             .toList());
+
+        this.specUpdatedAt = LocalDateTime.now();
     }
 
     public void updateAiReview(String aiReview) {

--- a/src/main/java/team/avgmax/rabbit/user/entity/User.java
+++ b/src/main/java/team/avgmax/rabbit/user/entity/User.java
@@ -17,23 +17,11 @@ import team.avgmax.rabbit.user.entity.enums.Role;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 public abstract class User extends BaseTime {
-    private String email;
-    private String password;
-    private String name;
-    private String image;
-
+    protected String email;
+    protected String password;
+    protected String name;
+    protected String image;
     @Enumerated(EnumType.STRING)
-    private Role role;
-    private String phone;
-
-    public void updateRoleToBunny() {
-        this.role = Role.ROLE_BUNNY;
-    }
-
-    // === 업데이트 메서드 ===
-    protected void updateUser(String name, String image, String email) {
-        if (name != null) this.name = name;
-        if (image != null) this.image = image;
-        if (email != null) this.email = email;
-    }
+    protected Role role;
+    protected String phone;
 }


### PR DESCRIPTION
## 📌 작업 개요
- 지표 계산 로직 구현

## ✅ 작업 상세
- 지표 계산 로직 명세서를 작성하고, 이를 코드로 구현했습니다. 로직이 복잡해서 BunnyIndicatorService 클래스를 별도로 만들었습니다.
- 엔티티 상속용 클래스 필드 접근제한자를 protected로 확장시켜서 상속받은 엔티티 클래스가 필드에 접근할 수 있도록 수정했습니다.

## 🎫 관련 이슈
- [RABBIT-88](https://dssw5.atlassian.net/browse/RABBIT-88)

## 🎬 참고 이미지

## 📎 기타
- 시가총액, 거래량, 성장률 등이 필요한 부분은 일단 배제했습니다. 지표 별 업데이트 필요한 시점은 [문서](https://www.notion.so/276c4f6364d0808b9537e6ae6e4028c2?source=copy_link)로 정리했습니다.