### PR TITLE
feat: [RABBIT-93] RABBIT 지수 조회 API 구현

### DIFF
--- a/src/main/java/team/avgmax/rabbit/bunny/controller/BunnyApiDocs.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/controller/BunnyApiDocs.java
@@ -16,11 +16,37 @@ import team.avgmax.rabbit.bunny.entity.enums.ChartInterval;
 import team.avgmax.rabbit.bunny.dto.orderBook.OrderBookSnapshot;
 import team.avgmax.rabbit.bunny.dto.request.OrderRequest;
 import team.avgmax.rabbit.bunny.dto.response.*;
+import team.avgmax.rabbit.bunny.dto.response.FetchBunnyResponse;
+import team.avgmax.rabbit.bunny.dto.response.MyBunnyResponse;
+import team.avgmax.rabbit.bunny.dto.response.RabbitIndexResponse;
 
 import java.util.List;
 
 @Tag(name = "Bunny", description = "버니 API")
 public interface BunnyApiDocs {
+    // ---------------- RABBIT 지수 조회 ----------------
+    @Operation(
+        summary = "RABBIT 지수 조회",
+        description = "RABBIT 지수를 조회합니다."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "RABBIT 지수 조회 성공",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = RabbitIndexResponse.class),
+                examples = @ExampleObject(
+                    value = """
+                    {
+                        "rabbit_index": 105.25
+                    }
+                    """
+                )
+            )
+        )
+    })
+    ResponseEntity<RabbitIndexResponse> getRabbitIndex();
 
     // ---------------- 버니 목록 조회 ----------------
     @Operation(

--- a/src/main/java/team/avgmax/rabbit/bunny/controller/BunnyController.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/controller/BunnyController.java
@@ -19,6 +19,7 @@ import team.avgmax.rabbit.bunny.entity.enums.BunnyFilter;
 import team.avgmax.rabbit.bunny.entity.enums.ChartInterval;
 import team.avgmax.rabbit.bunny.service.BunnyService;
 import team.avgmax.rabbit.bunny.dto.response.OrderResponse;
+import team.avgmax.rabbit.bunny.dto.response.RabbitIndexResponse;
 import team.avgmax.rabbit.user.entity.enums.Role;
 
 import java.net.URI;
@@ -31,6 +32,13 @@ import java.util.List;
 public class BunnyController implements BunnyApiDocs {
 
     private final BunnyService bunnyService;
+
+    // RABBIT 지수 조회
+    @GetMapping("/rabbit-index")
+    public ResponseEntity<RabbitIndexResponse> getRabbitIndex() {
+        log.info("GET RABBIT 지수 조회");
+        return ResponseEntity.ok(bunnyService.getRabbitIndex());
+    }
 
     // 버니 목록 조회
     @GetMapping

--- a/src/main/java/team/avgmax/rabbit/bunny/dto/response/RabbitIndexResponse.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/dto/response/RabbitIndexResponse.java
@@ -1,0 +1,13 @@
+package team.avgmax.rabbit.bunny.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import lombok.Builder;
+
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record RabbitIndexResponse(
+    double rabbitIndex
+) {
+}

--- a/src/main/java/team/avgmax/rabbit/bunny/repository/custom/BunnyRepositoryCustom.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/repository/custom/BunnyRepositoryCustom.java
@@ -21,4 +21,6 @@ public interface BunnyRepositoryCustom {
 
     List<Bunny> findAllWithUserOrderByMarketCapDesc();
 
+    BigDecimal sumCurrentMarketCap();
+
 }

--- a/src/main/java/team/avgmax/rabbit/bunny/repository/custom/BunnyRepositoryCustomImpl.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/repository/custom/BunnyRepositoryCustomImpl.java
@@ -64,6 +64,17 @@ public class BunnyRepositoryCustomImpl implements BunnyRepositoryCustom{
                 .fetch();
     }
 
+    @Override
+    public BigDecimal sumCurrentMarketCap() {
+        BigDecimal sum = queryFactory
+                .select(bunny.marketCap.sum())
+                .from(bunny)
+                .where(bunny.marketCap.isNotNull())
+                .fetchOne();
+        
+        return sum != null ? sum : BigDecimal.ZERO;
+    }
+
     private BigDecimal calculateAverageGrowthRate(com.querydsl.core.types.dsl.BooleanExpression condition) {
         NumberExpression<BigDecimal> growthRate = bunny.currentPrice.subtract(bunny.closingPrice)
                 .divide(bunny.closingPrice)

--- a/src/main/java/team/avgmax/rabbit/bunny/service/BunnyService.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/service/BunnyService.java
@@ -23,6 +23,7 @@ import team.avgmax.rabbit.bunny.dto.response.FetchBunnyResponse;
 import team.avgmax.rabbit.bunny.dto.response.MyBunnyResponse;
 import team.avgmax.rabbit.bunny.dto.response.OrderListResponse;
 import team.avgmax.rabbit.bunny.dto.response.OrderResponse;
+import team.avgmax.rabbit.bunny.dto.response.RabbitIndexResponse;
 import team.avgmax.rabbit.bunny.entity.*;
 import team.avgmax.rabbit.bunny.entity.enums.BunnyFilter;
 import team.avgmax.rabbit.bunny.entity.enums.BunnyType;
@@ -74,6 +75,27 @@ public class BunnyService {
     private final OrderBookPublisher orderBookPublisher;
     private final BunnyIndicatorService bunnyIndicatorService;
     private final MatchingEngine matchingEngine;
+
+    // RABBIT 지수 조회
+    @Transactional(readOnly = true)
+    public RabbitIndexResponse getRabbitIndex() {
+        BigDecimal baseMarketCapSum = BigDecimal.valueOf(bunnyRepository.count()).multiply(BigDecimal.valueOf(100_000_000));
+        BigDecimal currentMarketCapSum = bunnyRepository.sumCurrentMarketCap();
+        
+        double rabbitIndex;
+        if (baseMarketCapSum.compareTo(BigDecimal.ZERO) == 0) {
+            rabbitIndex = 100.0;
+        } else {
+            rabbitIndex = currentMarketCapSum
+                    .divide(baseMarketCapSum, 4, RoundingMode.HALF_UP)
+                    .multiply(BigDecimal.valueOf(100))
+                    .doubleValue();
+        }
+        
+        return RabbitIndexResponse.builder()
+                .rabbitIndex(rabbitIndex)
+                .build();
+    }
 
     // 버니 목록 조회
     @Transactional(readOnly = true) // 읽기 전용


### PR DESCRIPTION
## 📌 작업 개요
- RABBIT 지수 조회 API 구현

## ✅ 작업 상세
- RABBIT 지수(전체 기본 시가총액 대비 현재 시가총액 지수) 조회 구현했습니다.

## 🎫 관련 이슈
- [RABBIT-93](https://dssw5.atlassian.net/browse/RABBIT-93)

## 🎬 참고 이미지
<img width="1407" height="548" alt="스크린샷 2025-09-23 14 38 14" src="https://github.com/user-attachments/assets/6d948739-19d9-4c4c-ae01-d14a3d026caf" />

## 📎 기타
- 없음.