### PR TITLE
fix: [RABBIT-98] 버니 상세 조회 API 수정

### DIFF
--- a/src/main/java/team/avgmax/rabbit/bunny/dto/response/FetchBunnyResponse.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/dto/response/FetchBunnyResponse.java
@@ -9,6 +9,7 @@ import team.avgmax.rabbit.bunny.entity.Badge;
 import team.avgmax.rabbit.bunny.entity.Bunny;
 import team.avgmax.rabbit.bunny.entity.enums.BunnyType;
 import team.avgmax.rabbit.bunny.entity.enums.DeveloperType;
+import team.avgmax.rabbit.user.dto.response.SpecResponse;
 import team.avgmax.rabbit.user.entity.enums.Position;
 
 import java.math.BigDecimal;
@@ -52,6 +53,9 @@ public class FetchBunnyResponse {
     // 좋아요 수
     private long likeCount;
 
+    // 해당 버니의 스펙
+    private SpecResponse spec;
+
     // 시간
     private LocalDateTime createdAt; // 생성시간
 
@@ -75,6 +79,7 @@ public class FetchBunnyResponse {
                 .badges(bunny.getBadges().stream().map(Badge::getBadgeImg).toList())
                 .aiReview(bunny.getAiReview())
                 .likeCount(bunny.getLikeCount())
+                .spec(SpecResponse.from(bunny.getUser()))
                 .createdAt(bunny.getCreatedAt())
                 .build();
     }

--- a/src/main/java/team/avgmax/rabbit/bunny/exception/BunnyError.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/exception/BunnyError.java
@@ -13,7 +13,9 @@ public enum BunnyError implements ErrorCode {
     INSUFFICIENT_HOLDING(HttpStatus.BAD_REQUEST, "보유 수량이 부족합니다."),
     ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 주문을 찾을 수 없습니다."),
     FORBIDDEN(HttpStatus.FORBIDDEN, "해당 주문을 취소할 권한이 없습니다."),
-    ORDER_ALREADY_FILLED(HttpStatus.CONFLICT, "이미 체결이 완료된 주문은 취소할 수 없습니다.");
+    ORDER_ALREADY_FILLED(HttpStatus.CONFLICT, "이미 체결이 완료된 주문은 취소할 수 없습니다."),
+    NEGATIVE_HOLDING(HttpStatus.CONFLICT, "보유 수량이 마이너스 입니다."),
+    UNSUPPORTED_ORDER_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 주문 타입입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/team/avgmax/rabbit/bunny/service/BunnyService.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/service/BunnyService.java
@@ -261,7 +261,7 @@ public class BunnyService {
         switch (request.orderType()) {
             case BUY -> validateBuy(request, user);
             case SELL -> validateSell(bunny, request, user);
-            default -> throw new IllegalArgumentException("지원하지 않는 타입");
+            default -> throw new BunnyException(BunnyError.UNSUPPORTED_ORDER_TYPE);
         }
 
         // 신규 주문 저장 (초기 quantity = 요청 수량)
@@ -277,7 +277,7 @@ public class BunnyService {
 
         // 매도 시 매도량만큼 즉시 선차감
         if (myOrder.getOrderType() == OrderType.SELL) {
-            holdBunnyRepository.addHoldForUpdate(user.getId(), bunny.getId(), myOrder.getQuantity().negate());
+            holdBunnyRepository.adjustReservation(user.getId(), bunny.getId(), myOrder.getQuantity().negate());
         }
 
         // 오더북 Diff 용 터치 가격 (체결이 0건이어도 내 가격 레벨 반영)
@@ -335,7 +335,7 @@ public class BunnyService {
 
         // 매도자 취소시 남은 잔여 예약 수량 복원
         if (order.getOrderType() == OrderType.SELL) {
-            holdBunnyRepository.addHoldForUpdate(order.getUser().getId(), bunny.getId(), order.getQuantity());
+            holdBunnyRepository.adjustReservation(order.getUser().getId(), bunny.getId(), order.getQuantity());
         }
 
         // 주문 삭제 (취소 처리)

--- a/src/main/java/team/avgmax/rabbit/user/entity/HoldBunny.java
+++ b/src/main/java/team/avgmax/rabbit/user/entity/HoldBunny.java
@@ -33,7 +33,6 @@ public class HoldBunny extends BaseTime {
     @Column(precision = 30)
     private BigDecimal holdQuantity;
 
-    @Column(name = "total_buy_amount") //임시
     private BigDecimal costBasis;
 
     public static HoldBunny create(Bunny bunny, Funding funding) {

--- a/src/main/java/team/avgmax/rabbit/user/repository/custom/HoldBunnyRepositoryCustom.java
+++ b/src/main/java/team/avgmax/rabbit/user/repository/custom/HoldBunnyRepositoryCustom.java
@@ -14,7 +14,11 @@ public interface HoldBunnyRepositoryCustom {
 
     List<Tuple> findHolderTypeDistributionByBunnyId(String bunnyId);
 
-    void upsertForTrade(String userId, String bunnyId, BigDecimal qtyDelta, BigDecimal tradeBaseAmount, boolean adjustCost);
+    void applyBuyMatch(String userId, String bunnyId, BigDecimal qty, BigDecimal tradeBaseAmount);
 
-    void addHoldForUpdate(String userId, String bunnyId, BigDecimal deltaQty);
+    void applySellMatch(String userId, String bunnyId, BigDecimal filledQty);
+
+    void adjustReservation(String userId, String bunnyId, BigDecimal deltaQty);
+
+    void deleteIfEmpty(String userId, String bunnyId);
 }

--- a/src/main/java/team/avgmax/rabbit/user/repository/custom/HoldBunnyRepositoryCustomImpl.java
+++ b/src/main/java/team/avgmax/rabbit/user/repository/custom/HoldBunnyRepositoryCustomImpl.java
@@ -5,7 +5,10 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import com.querydsl.core.Tuple;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.JPAExpressions;
 import org.springframework.stereotype.Repository;
 
 import com.querydsl.core.types.Projections;
@@ -14,6 +17,10 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import team.avgmax.rabbit.bunny.dto.data.MyBunnyByHolderData;
 import team.avgmax.rabbit.bunny.entity.QBunny;
+import team.avgmax.rabbit.bunny.entity.QOrder;
+import team.avgmax.rabbit.bunny.entity.enums.OrderType;
+import team.avgmax.rabbit.bunny.exception.BunnyError;
+import team.avgmax.rabbit.bunny.exception.BunnyException;
 import team.avgmax.rabbit.global.util.UlidGenerator;
 import team.avgmax.rabbit.user.dto.response.HoldBunniesResponse;
 import team.avgmax.rabbit.user.dto.response.HoldBunnyResponse;
@@ -85,59 +92,51 @@ public class HoldBunnyRepositoryCustomImpl implements HoldBunnyRepositoryCustom 
     }
 
     @Override
-    public void upsertForTrade(String userId, String bunnyId, BigDecimal qtyDelta, BigDecimal tradeBaseAmount, boolean adjustCost) {
-
+    public void applyBuyMatch(String userId, String bunnyId, BigDecimal qty, BigDecimal tradeBaseAmount) {
         QHoldBunny hold = QHoldBunny.holdBunny;
-        NumberExpression<BigDecimal> newQtyExpr = hold.holdQuantity.add(qtyDelta);
-
-        // costBasis 계산 로직
-        NumberExpression<BigDecimal> newCostExpr =
-                com.querydsl.core.types.dsl.Expressions.cases()
-                        // 예약이면 원가 유지
-                        .when(com.querydsl.core.types.dsl.Expressions.booleanTemplate("{0} = false", adjustCost))
-                        .then(hold.costBasis)
-                        // 매수 체결이면 원가 += 체결 원금
-                        .when(com.querydsl.core.types.dsl.Expressions.booleanTemplate("{0} > 0", qtyDelta))
-                        .then(hold.costBasis.add(tradeBaseAmount))
-                        // 매도 체결이면 원가 비율 축소
-                        .when(com.querydsl.core.types.dsl.Expressions.booleanTemplate("{0} < 0 AND {1} > 0", qtyDelta, hold.holdQuantity))
-                        .then(
-                                hold.costBasis
-                                        .multiply(newQtyExpr)
-                                        .divide(hold.holdQuantity) // 정수 원단위로 관리, 필요시 반올림 조정
-                        )
-                        .otherwise(hold.costBasis);
 
         long updated = queryFactory.update(hold)
-                .set(hold.holdQuantity, newQtyExpr)
-                .set(hold.costBasis, newCostExpr)
+                .set(hold.holdQuantity, hold.holdQuantity.add(qty))
+                .set(hold.costBasis, hold.costBasis.add(tradeBaseAmount))
                 .where(hold.holder.id.eq(userId), hold.bunny.id.eq(bunnyId))
                 .execute();
 
-        // 기존 보유가 없는데 매수 체결이라면 새 insert
-        if (updated == 0 && qtyDelta.signum() > 0 && adjustCost) {
+        if (updated == 0) {
             String id = UlidGenerator.generateMonotonic();
             queryFactory.insert(hold)
                     .columns(hold.id, hold.holder.id, hold.bunny.id, hold.holdQuantity, hold.costBasis, hold.createdAt, hold.updatedAt)
-                    .values(id, userId, bunnyId, qtyDelta, tradeBaseAmount, LocalDateTime.now(), LocalDateTime.now())
-                    .execute();
-            return;
-        }
-
-        // 삭제는 체결(adjustCost=true)일 때만 허용
-        if (adjustCost) {
-            queryFactory.delete(hold)
-                    .where(
-                            hold.holder.id.eq(userId),
-                            hold.bunny.id.eq(bunnyId),
-                            hold.holdQuantity.loe(BigDecimal.ZERO)
-                    )
+                    .values(id, userId, bunnyId, qty, tradeBaseAmount, LocalDateTime.now(), LocalDateTime.now())
                     .execute();
         }
     }
 
     @Override
-    public void addHoldForUpdate(String userId, String bunnyId, BigDecimal deltaQty) {
+    public void applySellMatch(String userId, String bunnyId, BigDecimal filledQty) {
+        if (filledQty == null || filledQty.signum() <= 0) return;
+        QHoldBunny hold = QHoldBunny.holdBunny;
+
+        // oldQty = 현재 holdQuantity + filledQty (체결 전 보유 수량)
+        // newQty = holdQuantity (체결 후 보유 수량)
+        NumberExpression<BigDecimal> oldQty = hold.holdQuantity.add(filledQty);
+
+        // newCostBasis = costBasis * newQty / oldQty
+        NumberExpression<BigDecimal> newCostExpr =
+                new CaseBuilder()
+                        .when(oldQty.gt(BigDecimal.ZERO))
+                        .then(hold.costBasis.multiply(hold.holdQuantity).divide(oldQty))
+                        .otherwise(Expressions.constant(BigDecimal.ZERO));
+
+        queryFactory.update(hold)
+                .set(hold.costBasis, newCostExpr)
+                .where(
+                        hold.holder.id.eq(userId),
+                        hold.bunny.id.eq(bunnyId)
+                )
+                .execute();
+    }
+
+    @Override
+    public void adjustReservation(String userId, String bunnyId, BigDecimal deltaQty) {
         QHoldBunny hold = QHoldBunny.holdBunny;
 
         long updated = queryFactory.update(hold)
@@ -152,5 +151,47 @@ public class HoldBunnyRepositoryCustomImpl implements HoldBunnyRepositoryCustom 
                     .values(id, userId, bunnyId, deltaQty, BigDecimal.ZERO, LocalDateTime.now(), LocalDateTime.now())
                     .execute();
         }
+    }
+
+    @Override
+    public void deleteIfEmpty(String userId, String bunnyId) {
+        QHoldBunny hold = QHoldBunny.holdBunny;
+        QOrder order = QOrder.order;
+
+        // 현재 보유량 조회
+        BigDecimal qty = queryFactory
+                .select(hold.holdQuantity)
+                .from(hold)
+                .where(hold.holder.id.eq(userId), hold.bunny.id.eq(bunnyId))
+                .fetchOne();
+
+        // 행이 없으면 끝
+        if (qty == null) return;
+
+        // 음수면 즉시 예외 (트랜잭션 롤백)
+        if (qty.signum() < 0) {
+            throw new BunnyException(BunnyError.NEGATIVE_HOLDING);
+        } else if (qty.signum() > 0) return;
+
+        // 열린 SELL 주문 존재 여부
+        var hasOpenSell = JPAExpressions
+                .selectOne()
+                .from(order)
+                .where(
+                        order.user.id.eq(userId),
+                        order.bunny.id.eq(bunnyId),
+                        order.orderType.eq(OrderType.SELL),
+                        order.quantity.gt(BigDecimal.ZERO) // 잔량 > 0 인 열린 주문
+                );
+
+        // 보유가 0이고, 열린 SELL 주문이 없을 때만 삭제
+        queryFactory.delete(hold)
+                .where(
+                        hold.holder.id.eq(userId),
+                        hold.bunny.id.eq(bunnyId),
+                        // 열린 SELL 주문이 "없을 때만" 삭제
+                        hasOpenSell.notExists()
+                )
+                .execute();
     }
 }


### PR DESCRIPTION
## 📌 작업 개요
- 버니 상세 조회 API 수정

## ✅ 작업 상세
- 버니 상세 조회 API에 spec 추가
- 체결 로직 코드 최적화
[체결 로직]
- 매도 시, "예약 시와 체결 시"에서 차감되는 "이중차감 현상" 수정
- 평단가 계산 추가 (추가적으로 봐야할 것 같음)

## 🎫 관련 이슈
- [RABBIT-98](https://dssw5.atlassian.net/browse/RABBIT-98)

## 🎬 참고 이미지
- 
<img width="566" height="409" alt="image" src="https://github.com/user-attachments/assets/5dea6566-3af7-4d67-9682-402e23792eae" />
<img width="361" height="236" alt="BOT DB Test" src="https://github.com/user-attachments/assets/2ab9e829-cb28-4d9c-8aef-2eeac5421060" />


## 📎 기타
- 평단가 로직은 아직 완벽해 보이지 않아서 일단 구현만 해뒀고, 자세한 fix는 스케쥴러 구현 후 하려고 함.