### PR TITLE
refactor: [RABBIT-103] hold-bunnies DTO 수정

### DIFF
--- a/src/main/java/team/avgmax/rabbit/user/controller/PersonalUserApiDocs.java
+++ b/src/main/java/team/avgmax/rabbit/user/controller/PersonalUserApiDocs.java
@@ -324,16 +324,30 @@ public interface PersonalUserApiDocs {
                     {
                         "hold_bunnies": [
                             {
-                                "bunny_id": "01HZXBUNNY00000000000000001",
-                                "bunny_name": "bunny-001",
-                                "hold_quantity": 100,
-                                "total_buy_amount": 100000
+                                "bunnyId": "01HZXBUNNY00000000000000001",
+                                "bunnyName": "bunny-001",
+                                "holdQuantity": 100,
+                                "totalBuyAmount": 100000,
+                                "valuation": 120000,
+                                "avgPrice": 1000,
+                                "profitOrLoss": 20000,
+                                "returnRate": 20,
+                                "currentPrice": 1200,
+                                "priceDiffFromYesterday": 50,
+                                "priceChangeRate": 4.35
                             },
                             {
-                                "bunny_id": "01HZXBUNNY00000000000000002",
-                                "bunny_name": "bunny-002",
-                                "hold_quantity": 50,
-                                "total_buy_amount": 100000
+                                "bunnyId": "01HZXBUNNY00000000000000002",
+                                "bunnyName": "bunny-002",
+                                "holdQuantity": 50,
+                                "totalBuyAmount": 150000,
+                                "valuation": 140000,
+                                "avgPrice": 3000,
+                                "profitOrLoss": -10000,
+                                "returnRate": -6.67,
+                                "currentPrice": 2800,
+                                "priceDiffFromYesterday": -100,
+                                "priceChangeRate": -3.45
                             }
                         ]
                     }

--- a/src/main/java/team/avgmax/rabbit/user/dto/response/HoldBunniesResponse.java
+++ b/src/main/java/team/avgmax/rabbit/user/dto/response/HoldBunniesResponse.java
@@ -11,4 +11,10 @@ import lombok.Builder;
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record HoldBunniesResponse(
     List<HoldBunnyResponse> holdBunnies
-) {}
+) {
+    public static HoldBunniesResponse from(List<HoldBunnyResponse> holdBunnies) {
+        return HoldBunniesResponse.builder()
+            .holdBunnies(holdBunnies)
+            .build();
+    }
+}

--- a/src/main/java/team/avgmax/rabbit/user/dto/response/HoldBunnyResponse.java
+++ b/src/main/java/team/avgmax/rabbit/user/dto/response/HoldBunnyResponse.java
@@ -1,13 +1,56 @@
 package team.avgmax.rabbit.user.dto.response;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import lombok.Builder;
+import team.avgmax.rabbit.user.entity.HoldBunny;
 
 @Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record HoldBunnyResponse(
     String bunnyId,
     String bunnyName,
-    BigDecimal holdQuantity,
-    BigDecimal totalBuyAmount
-) {}
+    BigDecimal holdQuantity,    // 보유량
+    BigDecimal totalBuyAmount,  // 매입금액
+    BigDecimal valuation,       // 평가금액
+    BigDecimal avgPrice,        // 평균단가
+    BigDecimal profitOrLoss,    // 평가손익
+    BigDecimal returnRate,      // 수익률
+    BigDecimal currentPrice,    // 현재가
+    BigDecimal priceDiffFromYesterday, // 전일비
+    BigDecimal priceChangeRate  // 등락률
+) {
+    public static HoldBunnyResponse from(HoldBunny holdBunny) {
+        BigDecimal currentPrice = holdBunny.getBunny().getCurrentPrice(); //Bunny 엔티티가 보유한 가장 최신 거래가격
+        BigDecimal closingPrice = holdBunny.getBunny().getClosingPrice(); //Bunny 엔티티가 보유한 가장 최근 종가
+        BigDecimal valuation = holdBunny.getHoldQuantity().multiply(currentPrice); // 현재가 × 보유수량 = 지금 가지고 있는 자산의 시가 평가 총액
+        BigDecimal avgPrice = holdBunny.getCostBasis().divide(
+                holdBunny.getHoldQuantity(), RoundingMode.HALF_UP); // 	총 매입금액 / 총 보유수량 = 버니 하나를 얼마에 샀는지에 대한 평균
+        BigDecimal profitOrLoss = valuation.subtract(holdBunny.getCostBasis()); // 내 수익금
+        BigDecimal returnRate = profitOrLoss.divide(
+                holdBunny.getCostBasis(), RoundingMode.HALF_UP)
+                .multiply(BigDecimal.valueOf(100)); // 수익률 = (평가손익 / 총 매입금액) * 100
+        BigDecimal priceDiffFromYesterday = currentPrice.subtract(closingPrice); // 등락가 = 현재가 - 전일 종가
+        BigDecimal priceChangeRate = priceDiffFromYesterday.divide(
+                closingPrice, RoundingMode.HALF_UP)
+                .multiply(BigDecimal.valueOf(100)); // 등락률 = (전일비 / 전일 종가) * 100
+
+        return HoldBunnyResponse.builder()
+            .bunnyId(holdBunny.getBunny().getId())
+            .bunnyName(holdBunny.getBunny().getBunnyName())
+            .holdQuantity(holdBunny.getHoldQuantity())
+            .totalBuyAmount(holdBunny.getCostBasis())
+            .valuation(valuation)
+            .avgPrice(avgPrice)
+            .profitOrLoss(profitOrLoss)
+            .returnRate(returnRate)
+            .currentPrice(currentPrice)
+            .priceDiffFromYesterday(priceDiffFromYesterday)
+            .priceChangeRate(priceChangeRate)
+            .build();
+    }
+}

--- a/src/main/java/team/avgmax/rabbit/user/repository/HoldBunnyRepository.java
+++ b/src/main/java/team/avgmax/rabbit/user/repository/HoldBunnyRepository.java
@@ -14,8 +14,9 @@ import java.util.Optional;
 import java.util.List;
 
 public interface HoldBunnyRepository extends JpaRepository<HoldBunny, String>, HoldBunnyRepositoryCustom {
-
     List<HoldBunny> findByHolder(PersonalUser holder);
+
+    List<HoldBunny> findByHolderId(String personalUserId);
 
     Optional<HoldBunny> findByHolderAndBunny(PersonalUser holder, Bunny bunny);
 

--- a/src/main/java/team/avgmax/rabbit/user/repository/custom/HoldBunnyRepositoryCustom.java
+++ b/src/main/java/team/avgmax/rabbit/user/repository/custom/HoldBunnyRepositoryCustom.java
@@ -2,14 +2,10 @@ package team.avgmax.rabbit.user.repository.custom;
 
 import com.querydsl.core.Tuple;
 import team.avgmax.rabbit.bunny.dto.data.MyBunnyByHolderData;
-import team.avgmax.rabbit.user.dto.response.HoldBunniesResponse;
-
 import java.math.BigDecimal;
 import java.util.List;
 
 public interface HoldBunnyRepositoryCustom {
-    HoldBunniesResponse findHoldBunniesByUserId(String personalUserId);
-
     List<MyBunnyByHolderData> findHoldersByBunnyId(String bunnyId);
 
     List<Tuple> findHolderTypeDistributionByBunnyId(String bunnyId);

--- a/src/main/java/team/avgmax/rabbit/user/repository/custom/HoldBunnyRepositoryCustomImpl.java
+++ b/src/main/java/team/avgmax/rabbit/user/repository/custom/HoldBunnyRepositoryCustomImpl.java
@@ -15,6 +15,7 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
+
 import team.avgmax.rabbit.bunny.dto.data.MyBunnyByHolderData;
 import team.avgmax.rabbit.bunny.entity.QBunny;
 import team.avgmax.rabbit.bunny.entity.QOrder;
@@ -22,8 +23,6 @@ import team.avgmax.rabbit.bunny.entity.enums.OrderType;
 import team.avgmax.rabbit.bunny.exception.BunnyError;
 import team.avgmax.rabbit.bunny.exception.BunnyException;
 import team.avgmax.rabbit.global.util.UlidGenerator;
-import team.avgmax.rabbit.user.dto.response.HoldBunniesResponse;
-import team.avgmax.rabbit.user.dto.response.HoldBunnyResponse;
 import team.avgmax.rabbit.user.entity.QHoldBunny;
 import team.avgmax.rabbit.user.entity.QPersonalUser;
 
@@ -31,26 +30,6 @@ import team.avgmax.rabbit.user.entity.QPersonalUser;
 @RequiredArgsConstructor
 public class HoldBunnyRepositoryCustomImpl implements HoldBunnyRepositoryCustom {
     private final JPAQueryFactory queryFactory;
-
-    @Override
-    public HoldBunniesResponse findHoldBunniesByUserId(String personalUserId) {
-        QHoldBunny holdBunny = QHoldBunny.holdBunny;
-
-        List<HoldBunnyResponse> holdBunnies = queryFactory
-                .select(Projections.constructor(HoldBunnyResponse.class,
-                        holdBunny.bunny.id,
-                        holdBunny.bunny.bunnyName,
-                        holdBunny.holdQuantity,
-                        holdBunny.costBasis
-                        ))
-                .from(holdBunny)
-                .where(holdBunny.holder.id.eq(personalUserId))
-                .fetch();
-
-        return HoldBunniesResponse.builder()
-                .holdBunnies(holdBunnies)
-                .build();
-    }
 
     @Override
     public List<MyBunnyByHolderData> findHoldersByBunnyId(String bunnyId) {

--- a/src/main/java/team/avgmax/rabbit/user/service/PersonalUserService.java
+++ b/src/main/java/team/avgmax/rabbit/user/service/PersonalUserService.java
@@ -19,6 +19,7 @@ import team.avgmax.rabbit.user.dto.response.CarrotsResponse;
 import team.avgmax.rabbit.user.dto.response.FetchUserResponse;
 import team.avgmax.rabbit.user.dto.response.HoldBunniesResponse;
 import team.avgmax.rabbit.user.dto.response.HoldBunniesStatsResponse;
+import team.avgmax.rabbit.user.dto.response.HoldBunnyResponse;
 import team.avgmax.rabbit.user.dto.response.PersonalUserResponse;
 import team.avgmax.rabbit.user.entity.PersonalUser;
 import team.avgmax.rabbit.user.entity.enums.Role;
@@ -119,7 +120,11 @@ public class PersonalUserService {
 
     @Transactional(readOnly = true)
     public HoldBunniesResponse getBunniesById(String personalUserId) {
-        return holdBunnyRepository.findHoldBunniesByUserId(personalUserId);
+        List<HoldBunny> holdBunnies = holdBunnyRepository.findByHolderId(personalUserId);
+        List<HoldBunnyResponse> holdBunnyResponses = holdBunnies.stream()
+            .map(holdBunny -> HoldBunnyResponse.from(holdBunny))
+            .toList();
+        return HoldBunniesResponse.from(holdBunnyResponses);
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## 📌 작업 개요
- hold-bunnies DTO 수정

## ✅ 작업 상세
- 보유량, 평가손익, 수익률, 평가금액, 매입금액, 현재가, 평균단가, 전일비, 등락률 필드 추가 및 구조 변경 
- Swagger docs 수정

## 🎫 관련 이슈
- [RABBIT-103](https://dssw5.atlassian.net/browse/RABBIT-103)

## 🎬 참고 이미지
<img width="1422" height="888" alt="image" src="https://github.com/user-attachments/assets/3769560a-2bfb-4ac8-9145-4f21eb0d5281" />

## 📎 기타
- 없음.