### PR TITLE
feat: [RABBIT-102] 버니 상세에 유저 맞춤 정보 추가

### DIFF
--- a/src/main/java/team/avgmax/rabbit/bunny/controller/BunnyApiDocs.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/controller/BunnyApiDocs.java
@@ -17,6 +17,7 @@ import team.avgmax.rabbit.bunny.dto.orderBook.OrderBookSnapshot;
 import team.avgmax.rabbit.bunny.dto.request.OrderRequest;
 import team.avgmax.rabbit.bunny.dto.response.*;
 import team.avgmax.rabbit.bunny.dto.response.FetchBunnyResponse;
+import team.avgmax.rabbit.bunny.dto.response.BunnyUserContextResponse;
 import team.avgmax.rabbit.bunny.dto.response.MyBunnyResponse;
 import team.avgmax.rabbit.bunny.dto.response.RabbitIndexResponse;
 
@@ -135,6 +136,37 @@ public interface BunnyApiDocs {
     })
     ResponseEntity<FetchBunnyResponse> getBunny(
         @Parameter(description = "버니 이름", example = "bunny-001", required = true)
+        String bunnyName
+    );
+
+    // ---------------- 버니 사용자 컨텍스트 조회 ----------------
+    @Operation(
+        summary = "버니 사용자 컨텍스트 조회", 
+        description = "특정 버니에 대한 사용자의 매수/매도 가능한 금액과 수량을 조회합니다."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "사용자 컨텍스트 조회 성공",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = BunnyUserContextResponse.class),
+                examples = @ExampleObject(
+                    value = """
+                    {
+                        "is_liked": true,
+                        "buyable_amount": 5000000,
+                        "sellable_quantity": 100
+                    }
+                    """
+                )
+            )
+        ),
+        @ApiResponse(responseCode = "404", description = "해당 버니를 찾을 수 없습니다.")
+    })
+    ResponseEntity<BunnyUserContextResponse> getBunnyUserContext(
+        @Parameter(description = "버니 이름", example = "bunny-001", required = true)
+        @AuthenticationPrincipal Jwt jwt,
         String bunnyName
     );
 

--- a/src/main/java/team/avgmax/rabbit/bunny/controller/BunnyController.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/controller/BunnyController.java
@@ -13,6 +13,7 @@ import team.avgmax.rabbit.bunny.dto.orderBook.OrderBookSnapshot;
 import team.avgmax.rabbit.bunny.dto.request.OrderRequest;
 import team.avgmax.rabbit.bunny.dto.response.ChartResponse;
 import team.avgmax.rabbit.bunny.dto.response.FetchBunnyResponse;
+import team.avgmax.rabbit.bunny.dto.response.BunnyUserContextResponse;
 import team.avgmax.rabbit.bunny.dto.response.OrderListResponse;
 import team.avgmax.rabbit.bunny.dto.response.MyBunnyResponse;
 import team.avgmax.rabbit.bunny.entity.enums.BunnyFilter;
@@ -55,6 +56,15 @@ public class BunnyController implements BunnyApiDocs {
         log.info("GET 버니 상세 조회: {}",bunnyName);
 
         return ResponseEntity.ok(bunnyService.getBunnyByName(bunnyName));
+    }
+
+    // 버니 사용자 컨텍스트 조회
+    @GetMapping("/{bunnyName}/user-context")
+    public ResponseEntity<BunnyUserContextResponse> getBunnyUserContext(@AuthenticationPrincipal Jwt jwt, @PathVariable String bunnyName) {
+        String userId = jwt.getSubject();
+        log.info("GET 버니 사용자 컨텍스트 조회: {}, userId: {}", bunnyName, userId);
+
+        return ResponseEntity.ok(bunnyService.getBunnyUserContext(bunnyName, userId));
     }
 
     // 마이 버니 조회

--- a/src/main/java/team/avgmax/rabbit/bunny/dto/response/BunnyUserContextResponse.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/dto/response/BunnyUserContextResponse.java
@@ -1,0 +1,23 @@
+package team.avgmax.rabbit.bunny.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Builder;
+
+import java.math.BigDecimal;
+
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record BunnyUserContextResponse(
+    boolean isLiked,
+    BigDecimal buyableAmount,
+    BigDecimal sellableQuantity
+) {
+    public static BunnyUserContextResponse of(boolean isLiked, BigDecimal buyableAmount, BigDecimal sellableQuantity) {
+        return BunnyUserContextResponse.builder()
+                .isLiked(isLiked)
+                .buyableAmount(buyableAmount)
+                .sellableQuantity(sellableQuantity)
+                .build();
+    }
+}

--- a/src/main/java/team/avgmax/rabbit/bunny/dto/response/FetchBunnyResponse.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/dto/response/FetchBunnyResponse.java
@@ -71,6 +71,7 @@ public class FetchBunnyResponse {
                 .currentPrice(bunny.getCurrentPrice())
                 .closingPrice(bunny.getClosingPrice())
                 .marketCap(bunny.getMarketCap())
+                .fluctuationRate(calculateFluctuationRate(bunny.getCurrentPrice(), bunny.getClosingPrice()))
                 .growth(bunny.getGrowth())
                 .stability(bunny.getStability())
                 .value(bunny.getValue())
@@ -82,6 +83,15 @@ public class FetchBunnyResponse {
                 .spec(SpecResponse.from(bunny.getUser()))
                 .createdAt(bunny.getCreatedAt())
                 .build();
+    }
+
+    private static BigDecimal calculateFluctuationRate(BigDecimal currentPrice, BigDecimal closingPrice) {
+        if (currentPrice == null || closingPrice == null || closingPrice.compareTo(BigDecimal.ZERO) == 0) {
+            return BigDecimal.ZERO;
+        }
+        return currentPrice.subtract(closingPrice)
+                .divide(closingPrice, 4, java.math.RoundingMode.HALF_UP)
+                .multiply(BigDecimal.valueOf(100));
     }
 
 }

--- a/src/main/java/team/avgmax/rabbit/bunny/exception/BunnyError.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/exception/BunnyError.java
@@ -15,7 +15,9 @@ public enum BunnyError implements ErrorCode {
     FORBIDDEN(HttpStatus.FORBIDDEN, "해당 주문을 취소할 권한이 없습니다."),
     ORDER_ALREADY_FILLED(HttpStatus.CONFLICT, "이미 체결이 완료된 주문은 취소할 수 없습니다."),
     NEGATIVE_HOLDING(HttpStatus.CONFLICT, "보유 수량이 마이너스 입니다."),
-    UNSUPPORTED_ORDER_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 주문 타입입니다.");
+    UNSUPPORTED_ORDER_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 주문 타입입니다."),
+    ALREADY_LIKED(HttpStatus.CONFLICT, "이미 좋아요를 추가한 버니입니다."),
+    ALREADY_UNLIKED(HttpStatus.CONFLICT, "이미 좋아요를 취소한 버니입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/team/avgmax/rabbit/bunny/exception/BunnyException.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/exception/BunnyException.java
@@ -2,11 +2,15 @@ package team.avgmax.rabbit.bunny.exception;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import team.avgmax.rabbit.global.dto.ErrorCode;
 
 @Getter
 @RequiredArgsConstructor
 public class BunnyException extends RuntimeException {
 
-    private final ErrorCode errorCode;
+    private final BunnyError error;
+
+    @Override
+    public String getMessage() {
+        return error.getMessage();
+    }
 }

--- a/src/main/java/team/avgmax/rabbit/bunny/repository/BadgeRepository.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/repository/BadgeRepository.java
@@ -4,8 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import team.avgmax.rabbit.bunny.entity.Badge;
 import team.avgmax.rabbit.bunny.entity.id.BadgeId;
 
-import java.util.List;
-
 public interface BadgeRepository extends JpaRepository<Badge, BadgeId> {
     void deleteByBunnyIdAndUserId(String bunnyId, String userId);
 }

--- a/src/main/java/team/avgmax/rabbit/bunny/repository/custom/BunnyHistoryRepositoryCustomImpl.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/repository/custom/BunnyHistoryRepositoryCustomImpl.java
@@ -46,7 +46,8 @@ public class BunnyHistoryRepositoryCustomImpl implements BunnyHistoryRepositoryC
                 ))
                 .from(bunnyHistory)
                 .where(bunnyHistory.bunnyId.eq(bunnyId))
-                .orderBy(bunnyHistory.date.asc())
+                .orderBy(bunnyHistory.date.desc())
+                .limit(7)
                 .fetch();
     }
 
@@ -95,7 +96,8 @@ public class BunnyHistoryRepositoryCustomImpl implements BunnyHistoryRepositoryC
                 .from(bunnyHistory)
                 .where(bunnyHistory.bunnyId.eq(bunnyId))
                 .groupBy(weekKey)
-                .orderBy(weekKey.asc())
+                .orderBy(weekKey.desc())
+                .limit(7)
                 .fetch();
     }
 
@@ -145,7 +147,8 @@ public class BunnyHistoryRepositoryCustomImpl implements BunnyHistoryRepositoryC
                 .from(bunnyHistory)
                 .where(bunnyHistory.bunnyId.eq(bunnyId))
                 .groupBy(monthKey)
-                .orderBy(monthKey.asc())
+                .orderBy(monthKey.desc())
+                .limit(7)
                 .fetch();
     }
 

--- a/src/main/java/team/avgmax/rabbit/bunny/repository/custom/MatchRepositoryCustom.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/repository/custom/MatchRepositoryCustom.java
@@ -1,7 +1,6 @@
 package team.avgmax.rabbit.bunny.repository.custom;
 
 import team.avgmax.rabbit.bunny.entity.Match;
-import team.avgmax.rabbit.bunny.entity.enums.OrderType;
 
 import java.math.BigDecimal;
 import java.util.List;

--- a/src/main/java/team/avgmax/rabbit/bunny/repository/custom/MatchRepositoryCustomImpl.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/repository/custom/MatchRepositoryCustomImpl.java
@@ -1,16 +1,11 @@
 package team.avgmax.rabbit.bunny.repository.custom;
 
-import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
-import team.avgmax.rabbit.bunny.dto.response.MatchListResponse;
-import team.avgmax.rabbit.bunny.dto.response.MatchResponse;
 import team.avgmax.rabbit.bunny.entity.Match;
 import team.avgmax.rabbit.bunny.entity.QMatch;
-import team.avgmax.rabbit.bunny.entity.enums.OrderType;
-
 import java.math.BigDecimal;
 import java.util.List;
 

--- a/src/main/java/team/avgmax/rabbit/funding/dto/data/UserFundingSummary.java
+++ b/src/main/java/team/avgmax/rabbit/funding/dto/data/UserFundingSummary.java
@@ -11,6 +11,7 @@ import java.math.BigDecimal;
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record UserFundingSummary(
         PersonalUser user,
-        BigDecimal totalQuantity
+        BigDecimal totalQuantity,
+        String bunnyName
 ) {
 }

--- a/src/main/java/team/avgmax/rabbit/funding/dto/response/HoldingStatusResponse.java
+++ b/src/main/java/team/avgmax/rabbit/funding/dto/response/HoldingStatusResponse.java
@@ -15,8 +15,11 @@ import team.avgmax.rabbit.funding.entity.FundBunny;
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record HoldingStatusResponse(
         Double top1,
+        String top1Name,
         Double top2,
+        String top2Name,
         Double top3,
+        String top3Name,
         Double others,
         Double remaining
 ) {
@@ -27,8 +30,11 @@ public record HoldingStatusResponse(
         if (userFundingSummaries.isEmpty() || totalSupply.compareTo(BigDecimal.ZERO) == 0) {
             return HoldingStatusResponse.builder()
                     .top1(0.0)
+                    .top1Name("")
                     .top2(0.0)
+                    .top2Name("")
                     .top3(0.0)
+                    .top3Name("")
                     .others(0.0)
                     .remaining(100.0)
                     .build();
@@ -56,10 +62,17 @@ public record HoldingStatusResponse(
 
         return HoldingStatusResponse.builder()
                 .top1(top1)
+                .top1Name(getBunnyName(userFundingSummaries, 0))
                 .top2(top2)
+                .top2Name(getBunnyName(userFundingSummaries, 1))
                 .top3(top3)
+                .top3Name(getBunnyName(userFundingSummaries, 2))
                 .others(others)
                 .remaining(remaining)
                 .build();
+    }
+    
+    private static String getBunnyName(List<UserFundingSummary> summaries, int index) {
+        return summaries.size() > index ? summaries.get(index).bunnyName() : null;
     }
 }

--- a/src/main/java/team/avgmax/rabbit/funding/repository/FundingRepositoryCustomImpl.java
+++ b/src/main/java/team/avgmax/rabbit/funding/repository/FundingRepositoryCustomImpl.java
@@ -9,6 +9,7 @@ import team.avgmax.rabbit.funding.entity.FundBunny;
 import team.avgmax.rabbit.funding.entity.QFunding;
 import team.avgmax.rabbit.user.entity.PersonalUser;
 import team.avgmax.rabbit.user.entity.QPersonalUser;
+import team.avgmax.rabbit.bunny.entity.QBunny;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -23,17 +24,20 @@ public class FundingRepositoryCustomImpl implements FundingRepositoryCustom {
     public List<UserFundingSummary> findUserFundingSummariesByFundBunnyOrderByQuantityDesc(FundBunny fundBunny) {
         QFunding funding = QFunding.funding;
         QPersonalUser user = QPersonalUser.personalUser;
+        QBunny bunny = QBunny.bunny;
         
         return queryFactory
                 .select(Projections.constructor(
                         UserFundingSummary.class,
                         user,
-                        funding.quantity.sum()
+                        funding.quantity.sum(),
+                        bunny.bunnyName
                 ))
                 .from(funding)
                 .join(funding.user, user)
+                .leftJoin(bunny).on(bunny.user.eq(user))
                 .where(funding.fundBunny.eq(fundBunny))
-                .groupBy(user)
+                .groupBy(user, bunny.bunnyName)
                 .orderBy(funding.quantity.sum().desc())
                 .fetch();
     }

--- a/src/main/java/team/avgmax/rabbit/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/team/avgmax/rabbit/global/exception/GlobalExceptionHandler.java
@@ -7,17 +7,27 @@ import jakarta.servlet.http.HttpServletRequest;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-//import org.springframework.security.core.AuthenticationException;
-//import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.access.AccessDeniedException;
 
 import team.avgmax.rabbit.global.dto.ErrorResponse;
 import team.avgmax.rabbit.funding.exception.FundingException;
+import team.avgmax.rabbit.bunny.exception.BunnyException;
+import team.avgmax.rabbit.user.exception.UserException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
     // UserException 처리
+    @ExceptionHandler(UserException.class)
+    public ResponseEntity<ErrorResponse> handleUserException(UserException ex) {
+        return ErrorResponse.toResponseEntity(ex.getError());
+    }
 
     // BunnyException 처리
+    @ExceptionHandler(BunnyException.class)
+    public ResponseEntity<ErrorResponse> handleBunnyException(BunnyException ex) {
+        return ErrorResponse.toResponseEntity(ex.getError());
+    }
 
     // FundingException 처리
     @ExceptionHandler(FundingException.class)
@@ -31,17 +41,17 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
     }
 
-//    // Unauthentication 처리
-//    @ExceptionHandler(AuthenticationException.class)
-//    public ResponseEntity<Object> handleAuthenticationException(AuthenticationException ex) {
-//        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ex.getMessage());
-//    }
-//
-//    // Authorization 처리
-//    @ExceptionHandler(AccessDeniedException.class)
-//    public ResponseEntity<Object> handleAccessDeniedException(AccessDeniedException ex) {
-//        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ex.getMessage());
-//    }
+   // Unauthentication 처리
+   @ExceptionHandler(AuthenticationException.class)
+   public ResponseEntity<Object> handleAuthenticationException(AuthenticationException ex) {
+       return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ex.getMessage());
+   }
+
+   // Authorization 처리
+   @ExceptionHandler(AccessDeniedException.class)
+   public ResponseEntity<Object> handleAccessDeniedException(AccessDeniedException ex) {
+       return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ex.getMessage());
+   }
 
     // 기타 모든 예외 처리 (500 서버 에러)
     @ExceptionHandler(Exception.class)

--- a/src/main/java/team/avgmax/rabbit/user/controller/PersonalUserApiDocs.java
+++ b/src/main/java/team/avgmax/rabbit/user/controller/PersonalUserApiDocs.java
@@ -9,9 +9,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.multipart.MultipartFile;
 
 import team.avgmax.rabbit.user.dto.request.UpdatePersonalUserRequest;

--- a/src/main/java/team/avgmax/rabbit/user/exception/UserError.java
+++ b/src/main/java/team/avgmax/rabbit/user/exception/UserError.java
@@ -2,12 +2,13 @@ package team.avgmax.rabbit.user.exception;
 
 import org.springframework.http.HttpStatus;
 
+import team.avgmax.rabbit.global.dto.ErrorCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public enum UserError {
+public enum UserError implements ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
     CARROT_NOT_ENOUGH(HttpStatus.BAD_REQUEST, "캐럿이 부족합니다."),
     FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드 실패");

--- a/src/main/java/team/avgmax/rabbit/user/repository/custom/HoldBunnyRepositoryCustom.java
+++ b/src/main/java/team/avgmax/rabbit/user/repository/custom/HoldBunnyRepositoryCustom.java
@@ -17,4 +17,6 @@ public interface HoldBunnyRepositoryCustom {
     void adjustReservation(String userId, String bunnyId, BigDecimal deltaQty);
 
     void deleteIfEmpty(String userId, String bunnyId);
+
+    BigDecimal findTotalQuantityByUserIdAndBunnyId(String userId, String bunnyId);
 }

--- a/src/main/java/team/avgmax/rabbit/user/repository/custom/HoldBunnyRepositoryCustomImpl.java
+++ b/src/main/java/team/avgmax/rabbit/user/repository/custom/HoldBunnyRepositoryCustomImpl.java
@@ -173,4 +173,18 @@ public class HoldBunnyRepositoryCustomImpl implements HoldBunnyRepositoryCustom 
                 )
                 .execute();
     }
+
+    @Override
+    public BigDecimal findTotalQuantityByUserIdAndBunnyId(String userId, String bunnyId) {
+        QHoldBunny holdBunny = QHoldBunny.holdBunny;
+
+        BigDecimal result = queryFactory
+                .select(holdBunny.holdQuantity.sum())
+                .from(holdBunny)
+                .where(holdBunny.holder.id.eq(userId)
+                        .and(holdBunny.bunny.id.eq(bunnyId)))
+                .fetchOne();
+
+        return result != null ? result : BigDecimal.ZERO;
+    }
 }


### PR DESCRIPTION
## 📌 작업 개요
- 버니 상세에 유저 맞춤 정보 추가

## ✅ 작업 상세
- 버니 상세 조회를 할 때 로그인한 사용자의 좋아요 여부, 매수 가능 금액, 매도 가능 수량 응답 API 추가했습니다.
- 차트 데이터 7개씩만 응답되도록 수정했습니다. (프론트 요청)
- 버니 상세 조회에 등락률 로직 추가했습니다.
- 커스텀 Exception(Bunny, User)이 등록되어있지 않아서 추가했습니다.
- 펀드버니 지분 현황에 버니 이름 추가했습니다.

## 🎫 관련 이슈
- [RABBIT-102](https://dssw5.atlassian.net/browse/RABBIT-102)

## 🎬 참고 이미지
<img width="638" height="477" alt="image" src="https://github.com/user-attachments/assets/23a883b9-e728-4c59-8409-7184c60fc90d" />

## 📎 기타
- 없음.