### PR TITLE
fix: [RABBIT-111] 총 매입가 Query 수정

### DIFF
--- a/docker-compose.db.yml
+++ b/docker-compose.db.yml
@@ -12,7 +12,7 @@ services:
       MARIADB_PASSWORD: 1234
       TZ: Asia/Seoul
     ports:
-      - "3307:3306"
+      - "3306:3306"
   redis:
     image: redis:7.2
     container_name: redis

--- a/src/main/java/team/avgmax/rabbit/bunny/dto/response/MyBunnyResponse.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/dto/response/MyBunnyResponse.java
@@ -22,60 +22,53 @@ import java.util.List;
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class MyBunnyResponse {
 
-    // 요구사항 1: 코인명, 코인유형, 직군, 이름, 오늘날짜, 배지
+    // 코인 정보
     private String bunnyId;
-    private String userName; // 이름
+    private String userName;
     private String userImage;
-    private BigDecimal userCarrot; // 보유 캐럿
-    private String bunnyName; // 코인명
-    private BunnyType bunnyType; // 버니 유형 (희소, 밸런스, 단가)
-    private DeveloperType developerType; //  개발자 유형
-    private Position position; // 직군
-    private List<String> badges; // 배지
-    private LocalDate todayTime; // 오늘 날짜
+    private BigDecimal userCarrot;
+    private String bunnyName;
+    private BunnyType bunnyType;                 // 버니 유형 (희소 자산 / 밸런스 / 단가 친화)
+    private DeveloperType developerType;         // 개발자 유형 5가지
+    private Position position;                   // 직군
+    private List<String> badges;
+    private LocalDate todayTime;
 
-    // 요구사항 2: 성장성(차트)
-    private List<DailyPriceData> monthlyGrowthRates; // 전월말 ~ 이번월말 성장률
+    // 성장성 (차트)
+    private List<DailyPriceData> monthlyGrowthRates;   // 전월말 ~ 금월말 성장률
     private List<DailyPriceData> priceHistory;
 
-    // 요구사항 3: 시장 신뢰도
+    // 시장 신뢰도
     private int reliability;
 
-    // 요구사항 4: 시가총액, 현재가, 종가
     private BigDecimal currentPrice;
     private BigDecimal closingPrice;
-    private BigDecimal marketCap; // 시가 총액
+    private BigDecimal marketCap;                   // 시가 총액
 
-    // 요구사항 5: 삭제
-
-    // 요구사항 6: 경쟁 / 비교 지표
-    private BigDecimal avgBunnyTypeVsMe; // 버니 유형별 성장률 비교
-    private BigDecimal avgPositionVsMe; // 직군별 성장률 비교
-    private BigDecimal avgDevTypeVsMe; // 개발자 유형별 성장률 비교
-    private List<ComparisonData> competitors; // 경쟁자와 비교 (나와 가까운 순위 위아래)
+    // 비교 지표
+    private BigDecimal avgBunnyTypeVsMe;            // 버니 유형별 성장률 비교
+    private BigDecimal avgPositionVsMe;             // 직군별 성장률 비교
+    private BigDecimal avgDevTypeVsMe;              // 개발자 유형별 성장률 비교
+    private List<ComparisonData> competitors;       // 경쟁자와 비교 (나와 가까운 순위 위아래)
     private BigDecimal myGrowthRate;
 
-    // 요구사항 7: 개발자 유형 지표
+    // 개발자 유형 지표
     private int growth;
     private int stability;
     private int value;
     private int popularity;
     private int balance;
 
-    // 요구사항 9: 내 코인을 보유한 유형 및 보유자 확인
+    // 내 코인을 보유한 유형 및 보유자 확인
     private List<MyBunnyByDevTypeData> holderTypes;
     private List<MyBunnyByHolderData> holders;
 
-    // 요구사항 11: 성향 일치율 (거래 데이터 + 실제 성향)
-    private BigDecimal propensityMatchRate;
-
-    // 요구사항 12 : 나의 정보 + 스펙정보
+    // 나의 스펙 정보
     private SpecResponse spec;
 
-    // 요구사항 13 : AI 개선 제안
+    // AI 개선 제안
     private String aiReview;
     private String aiFeedback;
 
-    // 요구사항 14 : 좋아요 수
-    private long likeCount;
+    private long likeCount;                     // 좋아요 수
 }

--- a/src/main/java/team/avgmax/rabbit/bunny/exception/BunnyError.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/exception/BunnyError.java
@@ -9,16 +9,19 @@ import team.avgmax.rabbit.global.dto.ErrorCode;
 @RequiredArgsConstructor
 public enum BunnyError implements ErrorCode {
     BUNNY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 버니를 찾을 수 없습니다."),
+    ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 주문을 찾을 수 없습니다."),
+    BUNNYHISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 버니 기록을 찾을 수 없습니다."),
+    UNSUPPORTED_ORDER_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 주문 타입입니다."),
     INSUFFICIENT_BALANCE(HttpStatus.BAD_REQUEST, "보유 캐럿이 부족합니다."),
     INSUFFICIENT_HOLDING(HttpStatus.BAD_REQUEST, "보유 수량이 부족합니다."),
-    ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 주문을 찾을 수 없습니다."),
-    FORBIDDEN(HttpStatus.FORBIDDEN, "해당 주문을 취소할 권한이 없습니다."),
+    INVALID_PRICE(HttpStatus.BAD_REQUEST, "유효하지 않은 금액입니다."),
+    INVALID_QUANTITY(HttpStatus.BAD_REQUEST, "유효하지 않은 수량입니다."),
     ORDER_ALREADY_FILLED(HttpStatus.CONFLICT, "이미 체결이 완료된 주문은 취소할 수 없습니다."),
     NEGATIVE_HOLDING(HttpStatus.CONFLICT, "보유 수량이 마이너스 입니다."),
-    UNSUPPORTED_ORDER_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 주문 타입입니다."),
     ALREADY_LIKED(HttpStatus.CONFLICT, "이미 좋아요를 추가한 버니입니다."),
     ALREADY_UNLIKED(HttpStatus.CONFLICT, "이미 좋아요를 취소한 버니입니다."),
-    BUNNYHISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 버니 기록을 찾을 수 없습니다.");
+    FORBIDDEN(HttpStatus.FORBIDDEN, "해당 주문을 취소할 권한이 없습니다.");
+
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/team/avgmax/rabbit/bunny/service/match/MatchingEngine.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/service/match/MatchingEngine.java
@@ -84,7 +84,7 @@ public class MatchingEngine {
 
             // 보유 변동
             holdBunnyRepository.applyBuyMatch(buyer.getId(), bunny.getId(), tradable, tradeBaseAmt);
-            holdBunnyRepository.applySellMatch(seller.getId(), bunny.getId(), tradable);
+            holdBunnyRepository.applySellMatch(seller.getId(), bunny.getId(), tradeBaseAmt);
 
             // 주문 잔량 갱신
             remainingQty = remainingQty.subtract(tradable);

--- a/src/main/java/team/avgmax/rabbit/user/repository/HoldBunnyRepository.java
+++ b/src/main/java/team/avgmax/rabbit/user/repository/HoldBunnyRepository.java
@@ -18,8 +18,6 @@ public interface HoldBunnyRepository extends JpaRepository<HoldBunny, String>, H
 
     List<HoldBunny> findByHolderId(String personalUserId);
 
-    Optional<HoldBunny> findByHolderAndBunny(PersonalUser holder, Bunny bunny);
-
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select h from HoldBunny h where h.holder = :holder and h.bunny = :bunny")
     Optional<HoldBunny> findByHolderAndBunnyForUpdate(@Param("holder") PersonalUser holder,

--- a/src/main/java/team/avgmax/rabbit/user/repository/custom/HoldBunnyRepositoryCustom.java
+++ b/src/main/java/team/avgmax/rabbit/user/repository/custom/HoldBunnyRepositoryCustom.java
@@ -12,7 +12,7 @@ public interface HoldBunnyRepositoryCustom {
 
     void applyBuyMatch(String userId, String bunnyId, BigDecimal qty, BigDecimal tradeBaseAmount);
 
-    void applySellMatch(String userId, String bunnyId, BigDecimal filledQty);
+    void applySellMatch(String userId, String bunnyId, BigDecimal tradeBaseAmount);
 
     void adjustReservation(String userId, String bunnyId, BigDecimal deltaQty);
 


### PR DESCRIPTION
## Conflicts:
src/main/java/team/avgmax/rabbit/bunny/exception/BunnyError.java

## 📌 작업 개요
- 총 매입가 Query 수정

## ✅ 작업 상세
- 총 매입가의 쿼리를 체결가 x 체결갯수에 따른 증감으로 수정 했습니다.
- BunnyService의 매수/매도 검증 로직을 좀 더 강화 했습니다.
- 더 이상 사용하지 않는 코드 및 쿼리를 삭제 했습니다.

## 🎫 관련 이슈
- [RABBIT-111](https://dssw5.atlassian.net/browse/RABBIT-111)

## 🎬 참고 이미지
<img width="687" height="93" alt="image" src="https://github.com/user-attachments/assets/ed9e336a-a28c-43e5-ab8a-b8b7af787b56" />
<img width="676" height="107" alt="image" src="https://github.com/user-attachments/assets/a72cf7a2-75d4-41b4-b6af-3159bfe6a217" />

## 📎 기타
- 추가로 websocket 토큰 인가 임시 코드를 리팩토링 할 생각이고, 호가창에 Redis를 사용해볼 생각입니다.
- FE의 Trade 관련된 버그를 금일부터 시작할 생각입니다.