### PR TITLE
feat: [RABBIT-120] 개발자 지표 업데이트 연동

### DIFF
--- a/src/main/java/team/avgmax/rabbit/ai/controller/ChatModelApiDocs.java
+++ b/src/main/java/team/avgmax/rabbit/ai/controller/ChatModelApiDocs.java
@@ -12,6 +12,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestParam;
 import team.avgmax.rabbit.ai.dto.response.ScoreResponse;
 import team.avgmax.rabbit.auth.oauth2.CustomOAuth2User;
+import team.avgmax.rabbit.bunny.dto.response.AiBunnyResponse;
+
+import org.springframework.security.oauth2.jwt.Jwt;
 
 @Tag(name = "AI", description = "OpenAI chat API")
 public interface ChatModelApiDocs {
@@ -64,5 +67,36 @@ public interface ChatModelApiDocs {
     })
     ResponseEntity<ScoreResponse> score(
         @Parameter(description = "JWT 토큰", hidden = true) CustomOAuth2User customOAuth2User
+    );
+
+    @Operation(
+        summary = "AI 응답 동기화",
+        description = "버니의 AI 응답을 동기화합니다."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(
+        responseCode = "200",
+        description = "AI 응답 동기화 성공",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = AiBunnyResponse.class),
+            examples = @ExampleObject(
+                value = """
+                {
+                    "ai_review": "경영학 전공과 창업 경험을 토대로 사업 감각과 리더십을 겸비한 잠재력 높은 풀스택 전문가입니다.",
+                    "ai_feedback": "## 기술 역량 및 학습 방향\n현재 기술스택이 없기 때문에, 우선 풀스택 개발에 필수적인 최신 프레임워크와 도구를 체계적으로 학습하는 것이 중요합니다. 온라인 강의, 오픈소스 프로젝트 참여, 그리고 개인 포트폴리오 개발을 통해 실무 경험을 쌓으세요. 특히, 클라이언트-서버 연동과 배포 경험을 강조하면 시장 내 경쟁력을 높일 수 있습니다. 이를 통해 신뢰도와 가치 지표를 향상시키며, 성장 가능성도 함께 증대시킬 수 있습니다.## 자격증과 경력 강화 전략 \n현재 보유 자격증은 기술적 신뢰성을 높이지만, 실무경력 부재는 시장 평가에 영향을 줄 수 있습니다. 관련 프로젝트 또는 인턴십 경험을 적극적으로 쌓아 경력을 채우고, 프로젝트 결과물을 공개하는 것도 효과적입니다. 또한, 정보보안 관련 자격증을 활용해 보안 역량을 강화하면 시장 내 안정성과 신뢰도를 상승시킬 수 있습니다. 이와 함께, 자격증 취득 계획을 지속적으로 세워 학습 의지와 성장성을 보여주는 것도 중요합니다.## 시장 내 인지도 및 거래 활성화 방안\n버니 지표의 모든 항목이 높게 평가된 만큼, 시장 내 인지도 향상과 거래 활성화를 위해 온라인 커뮤니티, SNS, 블로그 등을 활용해 자신의 활동을 적극 알리세요. 특히, 시장 트렌드에 맞는 콘텐츠를 제작하거나, 커뮤니티 참여를 통해 신뢰와 인지도를 높이면 인기와 균형 지표도 상승할 것입니다. 마지막으로, 각종 온라인 세미나, 워크숍 참여를 통해 네트워크를 확장하면서 시장 내 영향력을 확대하는 전략도 추천합니다."
+                }
+                """
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "해당 버니를 찾을 수 없습니다."
+        )
+    })
+    ResponseEntity<AiBunnyResponse> sync(
+        @Parameter(description = "JWT 토큰", hidden = true) Jwt jwt,
+        @Parameter(description = "버니 이름") @RequestParam String bunnyName
     );
 }

--- a/src/main/java/team/avgmax/rabbit/ai/controller/ChatModelController.java
+++ b/src/main/java/team/avgmax/rabbit/ai/controller/ChatModelController.java
@@ -5,7 +5,9 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -13,6 +15,8 @@ import org.springframework.web.bind.annotation.RestController;
 import team.avgmax.rabbit.ai.dto.response.ScoreResponse;
 import team.avgmax.rabbit.ai.service.ChatModelService;
 import team.avgmax.rabbit.auth.oauth2.CustomOAuth2User;
+import team.avgmax.rabbit.bunny.dto.response.AiBunnyResponse;
+import team.avgmax.rabbit.bunny.service.BunnyService;
 import team.avgmax.rabbit.user.entity.PersonalUser;
 
 @Slf4j
@@ -22,6 +26,7 @@ import team.avgmax.rabbit.user.entity.PersonalUser;
 public class ChatModelController implements ChatModelApiDocs {
 
     private final ChatModelService chatModelService;
+    private final BunnyService bunnyService;
 
     @GetMapping("/ask")
     public ResponseEntity<String> ask(@AuthenticationPrincipal CustomOAuth2User customOAuth2User, @RequestParam String answer) {
@@ -36,5 +41,12 @@ public class ChatModelController implements ChatModelApiDocs {
         log.info("GET /ai/score: userId={}", personalUser.getId());
 
         return ResponseEntity.ok(chatModelService.score(personalUser));
+    }
+
+    @PatchMapping("/sync")
+    public ResponseEntity<AiBunnyResponse> sync(@AuthenticationPrincipal Jwt jwt, @RequestParam String bunnyName) {
+        String personalUserId = jwt.getSubject();
+        log.info("PATCH /ai/sync: personalUserId={}, bunnyName={}", personalUserId, bunnyName);
+        return ResponseEntity.ok(bunnyService.syncAiResponse(bunnyName));
     }
 }

--- a/src/main/java/team/avgmax/rabbit/bunny/dto/response/AiBunnyResponse.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/dto/response/AiBunnyResponse.java
@@ -1,0 +1,21 @@
+package team.avgmax.rabbit.bunny.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import lombok.Builder;
+import team.avgmax.rabbit.bunny.entity.Bunny;
+
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record AiBunnyResponse(
+    String aiReview,
+    String aiFeedback
+) {
+    public static AiBunnyResponse from(Bunny bunny) {
+        return AiBunnyResponse.builder()
+            .aiReview(bunny.getAiReview())
+            .aiFeedback(bunny.getAiFeedback())
+            .build();
+    }
+}

--- a/src/main/java/team/avgmax/rabbit/bunny/dto/response/FetchBunnyResponse.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/dto/response/FetchBunnyResponse.java
@@ -26,6 +26,7 @@ public class FetchBunnyResponse {
     private String bunnyId;
     private String userName;
     private String bunnyName;
+    private String image;
     private DeveloperType developerType;
     private BunnyType bunnyType;
     private Position position;
@@ -64,6 +65,7 @@ public class FetchBunnyResponse {
                 .bunnyId(bunny.getId())
                 .userName(bunny.getUser().getName())
                 .bunnyName(bunny.getBunnyName())
+                .image(bunny.getUser().getImage())
                 .developerType(bunny.getDeveloperType())
                 .bunnyType(bunny.getBunnyType())
                 .position(bunny.getUser().getPosition())

--- a/src/main/java/team/avgmax/rabbit/bunny/service/BunnyHistoryService.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/service/BunnyHistoryService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
 import team.avgmax.rabbit.bunny.entity.Bunny;
 import team.avgmax.rabbit.bunny.entity.BunnyHistory;
 import team.avgmax.rabbit.bunny.entity.enums.OrderType;
@@ -29,6 +30,8 @@ public class BunnyHistoryService {
     private final BunnyHistoryRepository bunnyHistoryRepository;
     private final MatchDailyAggregateRepository aggregateRepository;
     private final OrderRepository orderRepository;
+
+    private final BunnyIndicatorService bunnyIndicatorService;
 
     @Transactional
     public void aggregateFor(final LocalDate targetDate) {
@@ -91,6 +94,12 @@ public class BunnyHistoryService {
                     .build();
 
             bunnyHistoryRepository.save(history);
+            bunnyIndicatorService.updateBunnyGrowth(bunny);
+            bunnyIndicatorService.updateBunnyStability(bunny);
+            bunnyIndicatorService.updateBunnyPopularity(bunny);
+            bunnyIndicatorService.updateBunnyValue(bunny);
+            bunnyIndicatorService.updateBunnyBalance(bunny);
         }
+        
     }
 }

--- a/src/main/java/team/avgmax/rabbit/bunny/service/match/MatchingEngine.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/service/match/MatchingEngine.java
@@ -11,6 +11,7 @@ import team.avgmax.rabbit.bunny.entity.Order;
 import team.avgmax.rabbit.bunny.entity.enums.OrderType;
 import team.avgmax.rabbit.bunny.repository.MatchRepository;
 import team.avgmax.rabbit.bunny.repository.OrderRepository;
+import team.avgmax.rabbit.bunny.service.BunnyIndicatorService;
 import team.avgmax.rabbit.global.money.MoneyCalc;
 import team.avgmax.rabbit.user.entity.PersonalUser;
 import team.avgmax.rabbit.user.repository.HoldBunnyRepository;
@@ -30,6 +31,8 @@ public class MatchingEngine {
     private final OrderRepository orderRepository;
     private final HoldBunnyRepository holdBunnyRepository;
     private final PersonalUserRepository personalUserRepository;
+
+    private final BunnyIndicatorService bunnyIndicatorService;
 
     @Transactional(propagation = Propagation.MANDATORY)
     public MatchingResult match(Bunny bunny, Order myOrder, List<Order> candidates) {
@@ -115,6 +118,8 @@ public class MatchingEngine {
         } else {
             myOrder.updateQuantity(remainingQty); // 부분 체결 → 잔량 저장
         }
+
+        bunnyIndicatorService.updateBunnyValue(bunny);
 
         return new MatchingResult(touchedBid, touchedAsk);
     }

--- a/src/main/java/team/avgmax/rabbit/funding/dto/response/FundBunnyResponse.java
+++ b/src/main/java/team/avgmax/rabbit/funding/dto/response/FundBunnyResponse.java
@@ -17,6 +17,7 @@ import team.avgmax.rabbit.funding.entity.FundBunny;
 public record FundBunnyResponse(
     String fundBunnyId,
     String bunnyName,
+    String image,
     BunnyType bunnyType,
     BigDecimal targetBny,
     BigDecimal collectedBny,
@@ -28,6 +29,7 @@ public record FundBunnyResponse(
         return FundBunnyResponse.builder()
                 .fundBunnyId(fundBunny.getId())
                 .bunnyName(fundBunny.getBunnyName())
+                .image(fundBunny.getUser().getImage())
                 .bunnyType(fundBunny.getType())
                 .targetBny(fundBunny.getType().getTotalSupply())
                 .collectedBny(fundBunny.getCollectedBny())

--- a/src/main/java/team/avgmax/rabbit/user/repository/custom/HoldBunnyRepositoryCustomImpl.java
+++ b/src/main/java/team/avgmax/rabbit/user/repository/custom/HoldBunnyRepositoryCustomImpl.java
@@ -5,9 +5,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import com.querydsl.core.Tuple;
-import com.querydsl.core.types.dsl.CaseBuilder;
-import com.querydsl.core.types.dsl.Expressions;
-import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.JPAExpressions;
 import org.springframework.stereotype.Repository;
 


### PR DESCRIPTION
## 📌 작업 개요
- 개발자 지표 업데이트 연동

## ✅ 작업 상세
- RABBIT지수 기획 UI 정리(최대 200 ⇒ / 2)
- 펀드버니 목록 조회에 프로필 이미지 추가
- 지표 계산 시점 연동
    - 매일 자정 개발자 유형 지표 5가지 업데이트
    - AI 리뷰, 피드백 업데이트 API 추가
- 버니 정보에 프로필 이미지 추가

## 🎫 관련 이슈
- [RABBIT-120](https://dssw5.atlassian.net/browse/RABBIT-120)

## 🎬 참고 이미지
<img width="1610" height="587" alt="스크린샷 2025-09-26 17 53 51" src="https://github.com/user-attachments/assets/f45cb514-773b-48fd-a359-0b228c1fc992" />

## 📎 기타
- 없음.