### PR TITLE
fix: [RABBIT-129] 상장에 성공한 사용자 캐럿 미지급 오류 수정

### DIFF
--- a/src/main/java/team/avgmax/rabbit/funding/service/FundingService.java
+++ b/src/main/java/team/avgmax/rabbit/funding/service/FundingService.java
@@ -179,25 +179,28 @@ public class FundingService {
         // 1. 상장한 User의 Role을 BUNNY로 변경
         fundBunny.getUser().updateRoleToBunny();
 
-        // 2. FundBunny를 Bunny로 변환하여 저장
+        // 2. 상장한 User에게 캐럿 지급
+        fundBunny.getUser().addCarrot(fundBunny.getType().getMarketCap());
+
+        // 3. FundBunny를 Bunny로 변환하여 저장
         Bunny bunny = bunnyRepository.save(fundBunny.convertToBunny());
 
-        // 3. 해당 FundBunny의 모든 Funding 조회
+        // 4. 해당 FundBunny의 모든 Funding 조회
         List<Funding> fundings = fundingRepository.findByFundBunny(fundBunny);
         
-        // 4. 조회한 Funding들로 HoldBunny들을 생성하여 저장
+        // 5. 조회한 Funding들로 HoldBunny들을 생성하여 저장
         List<HoldBunny> holdBunnies = fundBunny.createHoldBunnies(bunny, fundings);
         holdBunnyRepository.saveAll(holdBunnies);
 
-        // 5. AI Review와 AI Feedback 생성
+        // 6. AI Review와 AI Feedback 생성
         String aiReview = chatClientService.getAiReviewOfBunny(bunny);
         String aiFeedback = chatClientService.getAiFeedbackOfBunny(bunny);
         bunny.updateAiReviewAndFeedback(aiReview, aiFeedback);
 
-        // 6. Redis에서 만료 키 제거 (상장되면 만료 처리할 필요 없음)
+        // 7. Redis에서 만료 키 제거 (상장되면 만료 처리할 필요 없음)
         redisUtil.deleteData("fund_bunny:" + fundBunny.getId());
 
-        // 7. FundBunny 삭제 (CASCADE로 Funding도 함께 삭제)
+        // 8. FundBunny 삭제 (CASCADE로 Funding도 함께 삭제)
         fundBunnyRepository.delete(fundBunny);
     }
 


### PR DESCRIPTION
## 📌 작업 개요
- 상장에 성공한 사용자 캐럿 미지급 오류 수정

## ✅ 작업 상세
- 상장에 성공하면 모인 캐럿을 상장한 사람에게 지급해야 하는데, 이 로직이 누락되었습니다. 이를 수정했습니다. (이미지의 2번 요구사항)

## 🎫 관련 이슈
- [RABBIT-129](https://dssw5.atlassian.net/browse/RABBIT-129)

## 🎬 참고 이미지
<img width="491" height="441" alt="image" src="https://github.com/user-attachments/assets/691fe379-2d56-451a-9df6-652eb1b514e5" />

## 📎 기타
- 없음.