### PR TITLE
refactor: [RABBIT-135] 호가창 매수 매도 응답 통합

### DIFF
--- a/src/main/java/team/avgmax/rabbit/bunny/controller/orderBook/OrderBookPublisher.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/controller/orderBook/OrderBookPublisher.java
@@ -16,12 +16,10 @@ public class OrderBookPublisher {
     public void publishDiff(String bunnyName, OrderBookDiff diff) {
         String destination = "/topic/bunnies/" + bunnyName + "/orderbook";
         log.info(
-                "호가 diff 전송: destination={}, bidUpserts={}, bidDeletes={}, askUpserts={}, askDeletes={}, currentPrice={}",
+                "호가 diff 전송: destination={}, orderUpserts={}, orderDeletes={}, currentPrice={}",
                 destination,
-                diff.bidUpserts().size(),
-                diff.bidDeletes().size(),
-                diff.askUpserts().size(),
-                diff.askDeletes().size(),
+                diff.orderUpserts().size(),
+                diff.orderDeletes().size(),
                 diff.currentPrice()
         );
 

--- a/src/main/java/team/avgmax/rabbit/bunny/controller/orderBook/OrderBookWsController.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/controller/orderBook/OrderBookWsController.java
@@ -20,7 +20,7 @@ public class OrderBookWsController {
     @SendTo("/topic/bunnies/{bunnyName}/orderbook")
     public OrderBookSnapshot sendSnapshot(@DestinationVariable String bunnyName) {
         OrderBookSnapshot snapshot = bunnyService.getOrderBookSnapshot(bunnyName);
-        log.info("WS snapshot 요청: bunnyName={}, bids={}, asks={}", bunnyName, snapshot.bids(), snapshot.asks());
+        log.debug("WS snapshot 요청: bunnyName={}, ordersCount={}", bunnyName, snapshot.orders().size());
 
         return snapshot;
     }

--- a/src/main/java/team/avgmax/rabbit/bunny/dto/orderBook/OrderBookDiff.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/dto/orderBook/OrderBookDiff.java
@@ -8,10 +8,8 @@ import java.util.List;
 // Diff 규칙 : upsert(추가/수정), delete(취소)
 public record OrderBookDiff(
         String bunnyName,
-        List<OrderBookLevel> bidUpserts,
-        List<BigDecimal> bidDeletes,
-        List<OrderBookLevel> askUpserts,
-        List<BigDecimal> askDeletes,
+        List<OrderBookLevel> orderUpserts,
+        List<BigDecimal> orderDeletes,
         BigDecimal currentPrice,
         long serverTime
 ) {}

--- a/src/main/java/team/avgmax/rabbit/bunny/dto/orderBook/OrderBookLevel.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/dto/orderBook/OrderBookLevel.java
@@ -1,8 +1,11 @@
 package team.avgmax.rabbit.bunny.dto.orderBook;
 
+import team.avgmax.rabbit.bunny.entity.enums.OrderType;
+
 import java.math.BigDecimal;
 
 public record OrderBookLevel(
         BigDecimal price,      // 해당 가격 레벨 대의 가격
-        BigDecimal quantity    // 해당 가격 레벨 대의 잔여량 (0보다 초과만 포함)
+        BigDecimal quantity,   // 해당 가격 레벨 대의 잔여량 (0보다 초과만 포함)
+        OrderType type         // 주문 타입 (BUY 또는 SELL)
 ) {}

--- a/src/main/java/team/avgmax/rabbit/bunny/dto/orderBook/OrderBookSnapshot.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/dto/orderBook/OrderBookSnapshot.java
@@ -7,21 +7,18 @@ import java.util.List;
 
 public record OrderBookSnapshot(
         String bunnyName,
-        List<OrderBookLevel> bids,  // 매수 레벨 목록
-        List<OrderBookLevel> asks,  // 매도 레벨 목록
+        List<OrderBookLevel> orders, // 호가창 레벨 목록
         BigDecimal currentPrice,    // 현재 기준 단가 (프론트에서 계산 : ((호가 - 현재가) / 현재가 * 100)
         long serverTime             // 서버 기준 시각(밀리초) → 프론트 동기화/지연 보정 참고용
 ) {
     public static OrderBookSnapshot from(
             Bunny bunny,
-            List<OrderBookLevel> bids,
-            List<OrderBookLevel> asks,
+            List<OrderBookLevel> orders,
             BigDecimal currentPrice
     ) {
         return new OrderBookSnapshot(
                 bunny.getBunnyName(),
-                bids,
-                asks,
+                orders,
                 currentPrice,
                 System.currentTimeMillis()
         );

--- a/src/main/java/team/avgmax/rabbit/bunny/exception/BunnyError.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/exception/BunnyError.java
@@ -20,7 +20,8 @@ public enum BunnyError implements ErrorCode {
     NEGATIVE_HOLDING(HttpStatus.CONFLICT, "보유 수량이 마이너스 입니다."),
     ALREADY_LIKED(HttpStatus.CONFLICT, "이미 좋아요를 추가한 버니입니다."),
     ALREADY_UNLIKED(HttpStatus.CONFLICT, "이미 좋아요를 취소한 버니입니다."),
-    FORBIDDEN(HttpStatus.FORBIDDEN, "해당 주문을 취소할 권한이 없습니다.");
+    FORBIDDEN(HttpStatus.FORBIDDEN, "해당 주문을 취소할 권한이 없습니다."),
+    HOLD_BUNNY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 버니 보유 정보를 찾을 수 없습니다.");
 
 
     private final HttpStatus status;

--- a/src/main/java/team/avgmax/rabbit/bunny/service/orderBook/OrderBookAssembler.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/service/orderBook/OrderBookAssembler.java
@@ -3,6 +3,7 @@ package team.avgmax.rabbit.bunny.service.orderBook;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import team.avgmax.rabbit.bunny.dto.orderBook.OrderBookLevel;
+import team.avgmax.rabbit.bunny.entity.enums.OrderType;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -15,8 +16,9 @@ public class OrderBookAssembler {
     private static final int DEFAULT_MAX_LEVELS = 20;
 
     public List<OrderBookLevel> toLevel(List<OrderLeaf> leaves) {
-        // 1) 가격 별 합산
-        Map<BigDecimal, BigDecimal> levelMap = new HashMap<>();
+        // 1) 매수와 매도로 분리하여 가격별 합산
+        Map<BigDecimal, BigDecimal> buyLevelMap = new HashMap<>();
+        Map<BigDecimal, BigDecimal> sellLevelMap = new HashMap<>();
 
         for (OrderLeaf leaf : leaves) {
             // 남은 수량이 없거나 음수면 호가창에 올리지 않음
@@ -25,23 +27,61 @@ public class OrderBookAssembler {
             BigDecimal priceKey = normalizePrice(leaf.price);
             if (priceKey == null) continue;
 
-            // 수량이 있으면 누적
-            levelMap.merge(priceKey, leaf.remainingQty(), BigDecimal::add);
+            // 매수/매도별로 수량 누적
+            if (leaf.orderType() == OrderType.BUY) {
+                buyLevelMap.merge(priceKey, leaf.remainingQty(), BigDecimal::add);
+            } else {
+                sellLevelMap.merge(priceKey, leaf.remainingQty(), BigDecimal::add);
+            }
         }
 
-
-        // 2) 불변 DTO 로 변환 및 정렬 및 상위 N개 슬라이싱 후 return
-        return levelMap.entrySet().stream()
+        // 2) 매수 레벨 정렬 (높은 가격부터), 매도 레벨 정렬 (낮은 가격부터)
+        List<OrderBookLevel> buyLevels = buyLevelMap.entrySet().stream()
                 .filter(e -> e.getValue() != null && e.getValue().signum() > 0)
-                .map(e -> new OrderBookLevel(e.getKey(), e.getValue()))
-                .sorted(Comparator.comparing(OrderBookLevel::price).reversed())
-                .limit(DEFAULT_MAX_LEVELS)
+                .map(e -> new OrderBookLevel(e.getKey(), e.getValue(), OrderType.BUY))
+                .sorted(Comparator.comparing(OrderBookLevel::price).reversed()) // 높은 가격부터
                 .toList();
+
+        List<OrderBookLevel> sellLevels = sellLevelMap.entrySet().stream()
+                .filter(e -> e.getValue() != null && e.getValue().signum() > 0)
+                .map(e -> new OrderBookLevel(e.getKey(), e.getValue(), OrderType.SELL))
+                .sorted(Comparator.comparing(OrderBookLevel::price)) // 낮은 가격부터
+                .toList();
+
+        // 3) 전체 한도(DEFAULT_MAX_LEVELS) 내에서 매수/매도 비율 조정
+        return combineBuyAndSellLevels(buyLevels, sellLevels);
+    }
+
+    private List<OrderBookLevel> combineBuyAndSellLevels(List<OrderBookLevel> buyLevels, List<OrderBookLevel> sellLevels) {
+        List<OrderBookLevel> result = new ArrayList<>();
+        List<OrderBookLevel> buyList = new ArrayList<>(buyLevels);
+        List<OrderBookLevel> sellList = new ArrayList<>(sellLevels);
+
+        // 각각 최대 10개씩 추가
+        int buyCount = Math.min(buyList.size(), 10);
+        int sellCount = Math.min(sellList.size(), 10);
+        
+        // 부족한 한쪽에 대해 다른쪽에서 보충
+        if (buyCount < 10 && sellList.size() > 10) {
+            sellCount = Math.min(10 + (10 - buyCount), sellList.size());
+        } else if (sellCount < 10 && buyList.size() > 10) {
+            buyCount = Math.min(10 + (10 - sellCount), buyList.size());
+        }
+
+        // 결과 조합
+        result.addAll(buyList.subList(0, buyCount));
+        result.addAll(sellList.subList(0, sellCount));
+
+        // 가격 기준 내림차순 정렬
+        result.sort(Comparator.comparing(OrderBookLevel::price).reversed());
+
+        return result;
     }
 
     public record OrderLeaf(
             BigDecimal price,
-            BigDecimal remainingQty
+            BigDecimal remainingQty,
+            OrderType orderType
     ) {}
 
     public static BigDecimal normalizePrice(BigDecimal price) {

--- a/src/main/java/team/avgmax/rabbit/global/config/SecurityConfig.java
+++ b/src/main/java/team/avgmax/rabbit/global/config/SecurityConfig.java
@@ -57,7 +57,7 @@ public class SecurityConfig {
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/login/**", "/error", "/auth/dummy").permitAll()
                 .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
-//                .requestMatchers("/ws/**").permitAll() // WebSocket 연결 허용
+               .requestMatchers("/ws/**").permitAll() // WebSocket 연결 허용
                 .requestMatchers("/user/**", "/auth/**", "/ai/**").hasRole("USER")
                 .requestMatchers(HttpMethod.POST, "/fund-bunnies").hasRole("USER")
                 .requestMatchers("/fund-bunnies/**").hasAnyRole("USER", "BUNNY")

--- a/src/main/java/team/avgmax/rabbit/user/dto/response/HoldBunnyResponse.java
+++ b/src/main/java/team/avgmax/rabbit/user/dto/response/HoldBunnyResponse.java
@@ -27,23 +27,40 @@ public record HoldBunnyResponse(
     public static HoldBunnyResponse from(HoldBunny holdBunny) {
         BigDecimal currentPrice = holdBunny.getBunny().getCurrentPrice(); //Bunny 엔티티가 보유한 가장 최신 거래가격
         BigDecimal closingPrice = holdBunny.getBunny().getClosingPrice(); //Bunny 엔티티가 보유한 가장 최근 종가
-        BigDecimal valuation = holdBunny.getHoldQuantity().multiply(currentPrice); // 현재가 × 보유수량 = 지금 가지고 있는 자산의 시가 평가 총액
-        BigDecimal avgPrice = holdBunny.getCostBasis().divide(
-                holdBunny.getHoldQuantity(), RoundingMode.HALF_UP); // 	총 매입금액 / 총 보유수량 = 버니 하나를 얼마에 샀는지에 대한 평균
-        BigDecimal profitOrLoss = valuation.subtract(holdBunny.getCostBasis()); // 내 수익금
-        BigDecimal returnRate = profitOrLoss.divide(
-                holdBunny.getCostBasis(), RoundingMode.HALF_UP)
-                .multiply(BigDecimal.valueOf(100)); // 수익률 = (평가손익 / 총 매입금액) * 100
+        BigDecimal holdQuantity = holdBunny.getHoldQuantity();
+        BigDecimal costBasis = holdBunny.getCostBasis();
+        
+        BigDecimal valuation = holdQuantity.multiply(currentPrice); // 현재가 × 보유수량 = 지금 가지고 있는 자산의 시가 평가 총액
+        
+        // 안전한 나누기: 0으로 나누기 방지
+        BigDecimal avgPrice = BigDecimal.ZERO;
+        if (holdQuantity.compareTo(BigDecimal.ZERO) != 0) {
+            avgPrice = costBasis.divide(holdQuantity, RoundingMode.HALF_UP); // 총 매입금액 / 총 보유수량 = 버니 하나를 얼마에 샀는지에 대한 평균
+        }
+        
+        BigDecimal profitOrLoss = valuation.subtract(costBasis); // 내 수익금
+        
+        // 안전한 나누기: costBasis가 0이 아니면 수익률 계산
+        BigDecimal returnRate = BigDecimal.ZERO;
+        if (costBasis.compareTo(BigDecimal.ZERO) != 0) {
+            returnRate = profitOrLoss.divide(costBasis, RoundingMode.HALF_UP)
+                    .multiply(BigDecimal.valueOf(100)); // 수익률 = (평가손익 / 총 매입금액) * 100
+        }
+        
         BigDecimal priceDiffFromYesterday = currentPrice.subtract(closingPrice); // 등락가 = 현재가 - 전일 종가
-        BigDecimal priceChangeRate = priceDiffFromYesterday.divide(
-                closingPrice, RoundingMode.HALF_UP)
-                .multiply(BigDecimal.valueOf(100)); // 등락률 = (전일비 / 전일 종가) * 100
+        
+        // 안전한 나누기: closingPrice가 0이 아니면 등락률 계산
+        BigDecimal priceChangeRate = BigDecimal.ZERO;
+        if (closingPrice != null && closingPrice.compareTo(BigDecimal.ZERO) != 0) {
+            priceChangeRate = priceDiffFromYesterday.divide(closingPrice, RoundingMode.HALF_UP)
+                    .multiply(BigDecimal.valueOf(100)); // 등락률 = (전일비 / 전일 종가) * 100
+        }
 
         return HoldBunnyResponse.builder()
             .bunnyId(holdBunny.getBunny().getId())
             .bunnyName(holdBunny.getBunny().getBunnyName())
-            .holdQuantity(holdBunny.getHoldQuantity())
-            .totalBuyAmount(holdBunny.getCostBasis())
+            .holdQuantity(holdQuantity)
+            .totalBuyAmount(costBasis)
             .valuation(valuation)
             .avgPrice(avgPrice)
             .profitOrLoss(profitOrLoss)

--- a/src/main/java/team/avgmax/rabbit/user/entity/HoldBunny.java
+++ b/src/main/java/team/avgmax/rabbit/user/entity/HoldBunny.java
@@ -30,8 +30,9 @@ public class HoldBunny extends BaseTime {
     @JoinColumn(name = "bunny_id", nullable = false)
     private Bunny bunny;
 
+    @Builder.Default
     @Column(precision = 30)
-    private BigDecimal holdQuantity;
+    private BigDecimal holdQuantity = BigDecimal.ZERO;
 
     @Builder.Default
     private BigDecimal costBasis = BigDecimal.ZERO;
@@ -43,5 +44,22 @@ public class HoldBunny extends BaseTime {
                 .holdQuantity(funding.getQuantity())
                 .costBasis(bunny.getCurrentPrice().multiply(funding.getQuantity()))
                 .build();
+    }
+
+    public static HoldBunny create(Bunny bunny, PersonalUser user) {
+        return HoldBunny.builder()
+                .bunny(bunny)
+                .holder(user)
+                .build();
+    }
+
+    public void applySellMatch(BigDecimal quantity, BigDecimal amount) {
+        this.holdQuantity = this.holdQuantity.subtract(quantity);
+        this.costBasis = this.costBasis.subtract(amount);
+    }
+
+    public void applyBuyMatch(BigDecimal quantity, BigDecimal amount) {
+        this.holdQuantity = this.holdQuantity.add(quantity);
+        this.costBasis = this.costBasis.add(amount);
     }
 }

--- a/src/main/java/team/avgmax/rabbit/user/repository/HoldBunnyRepository.java
+++ b/src/main/java/team/avgmax/rabbit/user/repository/HoldBunnyRepository.java
@@ -22,4 +22,6 @@ public interface HoldBunnyRepository extends JpaRepository<HoldBunny, String>, H
     @Query("select h from HoldBunny h where h.holder = :holder and h.bunny = :bunny")
     Optional<HoldBunny> findByHolderAndBunnyForUpdate(@Param("holder") PersonalUser holder,
                                                       @Param("bunny") Bunny bunny);
+
+    Optional<HoldBunny> findByHolderAndBunny(PersonalUser holder, Bunny bunny);
 }


### PR DESCRIPTION
## 📌 작업 개요
- 호가창 매수 매도 응답 통합

## ✅ 작업 상세
- 기존에 asks, bids 구조로 응답하던 웹소켓 orders로 통합했습니다.
- 보유버니 로직에 의해 매도 주문 안되는 오류 수정했습니다.

## 🎫 관련 이슈
- [RABBIT-135](https://dssw5.atlassian.net/browse/RABBIT-135)

## 🎬 참고 이미지

## 📎 기타
- ws permit all 했습니다.