### PR TITLE
feat: [RABBIT-155] 뱃지 별 보유자 목록 조회 API 구현

### DIFF
--- a/src/main/java/team/avgmax/rabbit/bunny/controller/BunnyApiDocs.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/controller/BunnyApiDocs.java
@@ -664,4 +664,64 @@ public interface BunnyApiDocs {
 
     @Operation(summary = "거래 체결강도 top5", description = "모든 버니들의 매수/ 매도 체결강도 중 top5를 조회함")
     ResponseEntity<PressureResponse> getPressureTop5();
+
+    // ---------------- 뱃지 별 보유자 목록 조회 ----------------
+    @Operation(
+        summary = "뱃지 별 보유자 목록 조회", 
+        description = "특정 뱃지를 보유한 버니들의 목록을 조회합니다."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "뱃지 보유자 목록 조회 성공",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = BadgeHolderListResponse.class),
+                examples = @ExampleObject(
+                    value = """
+                    {
+                        "size": 3,
+                        "badge_name": "kakao",
+                        "badge_img": "KAKAO",
+                        "badge_holders": [
+                            {
+                            "bunny_id": "01BUNNY0010000000000000031",
+                            "bunny_name": "dreamwave",
+                            "image": "https://minio.avgmax.team/rabbit/bunny_031.png"
+                            },
+                            {
+                            "bunny_id": "01BUNNY0010000000000000033",
+                            "bunny_name": "seoulsunset",
+                            "image": "https://minio.avgmax.team/rabbit/bunny_033.png"
+                            },
+                            {
+                            "bunny_id": "01BUNNY0010000000000000034",
+                            "bunny_name": "dock-yard",
+                            "image": "https://minio.avgmax.team/rabbit/bunny_034.png"
+                            }
+                        ]
+                    }
+                    """
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "사용자를 찾을 수 없음",
+            content = @Content(
+                mediaType = "application/json",
+                examples = @ExampleObject(
+                    value = """
+                    {
+                        "error": "USER_NOT_FOUND",
+                        "message": "사용자를 찾을 수 없습니다."
+                    }
+                    """
+                )
+            )
+        )
+    })
+    ResponseEntity<BadgeHolderListResponse> getBadgeHolders(
+        @Parameter(description = "뱃지 이름", example = "kakao") String badgeName
+    );
 }

--- a/src/main/java/team/avgmax/rabbit/bunny/controller/BunnyController.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/controller/BunnyController.java
@@ -16,6 +16,7 @@ import lombok.extern.slf4j.Slf4j;
 import team.avgmax.rabbit.bunny.dto.orderBook.OrderBookSnapshot;
 import team.avgmax.rabbit.bunny.dto.request.OrderRequest;
 import team.avgmax.rabbit.bunny.dto.response.ChartResponse;
+import team.avgmax.rabbit.bunny.dto.response.BadgeHolderListResponse;
 import team.avgmax.rabbit.bunny.dto.response.FetchBunnyResponse;
 import team.avgmax.rabbit.bunny.dto.response.BunnyUserContextResponse;
 import team.avgmax.rabbit.bunny.dto.response.OrderListResponse;
@@ -178,4 +179,10 @@ public class BunnyController implements BunnyApiDocs {
         return ResponseEntity.ok(bunnyHistoryService.getTop5ByPressure());
     }
 
+    // 뱃지 별 보유자 목록 조회
+    @GetMapping("/badges/{badgeName}/holders")
+    public ResponseEntity<BadgeHolderListResponse> getBadgeHolders(@PathVariable String badgeName) {
+        log.info("GET 뱃지 별 보유자 목록 조회: {}", badgeName);
+        return ResponseEntity.ok(bunnyService.getBadgeHolders(badgeName));
+    }
 }

--- a/src/main/java/team/avgmax/rabbit/bunny/dto/response/BadgeHolderListResponse.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/dto/response/BadgeHolderListResponse.java
@@ -1,0 +1,45 @@
+package team.avgmax.rabbit.bunny.dto.response;
+
+import java.util.List;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import lombok.Builder;
+import team.avgmax.rabbit.bunny.entity.Bunny;
+
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)   
+public record BadgeHolderListResponse(
+    long size,
+    String badgeName,
+    String badgeImg,
+    List<BadgeHolderResponse> badgeHolders
+) {
+    @Builder
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public record BadgeHolderResponse(
+        String bunnyId,
+        String bunnyName,
+        String image
+    ) {
+        public static BadgeHolderResponse from(Bunny bunny) {
+            return BadgeHolderResponse.builder()
+                .bunnyId(bunny.getId())
+                .bunnyName(bunny.getBunnyName())
+                .image(bunny.getUser().getImage())
+                .build();
+        }
+    }
+
+    public static BadgeHolderListResponse from(String badgeImg, List<Bunny> bunnies) {
+        return BadgeHolderListResponse.builder()
+                .size(bunnies.size())
+                .badgeName(badgeImg.toLowerCase())
+                .badgeImg(badgeImg)
+                .badgeHolders(bunnies.stream()
+                        .map(BadgeHolderResponse::from)
+                        .toList())
+                .build();
+    }
+}

--- a/src/main/java/team/avgmax/rabbit/bunny/repository/BadgeRepository.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/repository/BadgeRepository.java
@@ -1,9 +1,13 @@
 package team.avgmax.rabbit.bunny.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
 import team.avgmax.rabbit.bunny.entity.Badge;
 import team.avgmax.rabbit.bunny.entity.id.BadgeId;
 
 public interface BadgeRepository extends JpaRepository<Badge, BadgeId> {
     void deleteByBunnyIdAndUserId(String bunnyId, String userId);
+    List<Badge> findAllByBadgeImg(String badgeImg);
 }

--- a/src/main/java/team/avgmax/rabbit/bunny/repository/custom/BunnyRepositoryCustom.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/repository/custom/BunnyRepositoryCustom.java
@@ -24,4 +24,6 @@ public interface BunnyRepositoryCustom {
     BigDecimal sumCurrentMarketCap();
 
     List<Bunny> findTop10ByOrderBySpecUpdatedAtDesc();
+
+    List<Bunny> findAllByBadgeImg(String badgeImg);
 }

--- a/src/main/java/team/avgmax/rabbit/bunny/repository/custom/BunnyRepositoryCustomImpl.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/repository/custom/BunnyRepositoryCustomImpl.java
@@ -103,4 +103,14 @@ public class BunnyRepositoryCustomImpl implements BunnyRepositoryCustom{
                 .limit(10)
                 .fetch();
     }
+
+    @Override
+    public List<Bunny> findAllByBadgeImg(String badgeImg) {
+        return queryFactory
+                .select(bunny)
+                .from(badge)
+                .join(bunny).on(badge.bunnyId.eq(bunny.id))
+                .where(badge.badgeImg.eq(badgeImg))
+                .fetch();
+    }
 }

--- a/src/main/java/team/avgmax/rabbit/bunny/service/BunnyService.java
+++ b/src/main/java/team/avgmax/rabbit/bunny/service/BunnyService.java
@@ -26,6 +26,7 @@ import team.avgmax.rabbit.bunny.dto.response.ChartDataPoint;
 import team.avgmax.rabbit.bunny.dto.response.ChartResponse;
 import team.avgmax.rabbit.bunny.dto.response.FetchBunnyResponse;
 import team.avgmax.rabbit.bunny.dto.response.AiBunnyResponse;
+import team.avgmax.rabbit.bunny.dto.response.BadgeHolderListResponse;
 import team.avgmax.rabbit.bunny.dto.response.BunnyUserContextResponse;
 import team.avgmax.rabbit.bunny.dto.response.MyBunnyResponse;
 import team.avgmax.rabbit.bunny.dto.response.OrderListResponse;
@@ -77,9 +78,9 @@ public class BunnyService {
     private final HoldBunnyRepository holdBunnyRepository;
     private final BunnyLikeRepository bunnyLikeRepository;
     private final PersonalUserRepository personalUserRepository;
+    private final CorporationUserRepository corporationUserRepository;
     private final OrderRepository orderRepository;
     private final MatchRepository matchRepository;
-    private final CorporationUserRepository corporationUserRepository;
     private final OrderBookAssembler orderBookAssembler;
     private final OrderBookPublisher orderBookPublisher;
     private final PriceTickPublisher priceTickPublisher;
@@ -307,8 +308,7 @@ public class BunnyService {
         }
 
         // 신규 주문 저장 (초기 quantity = 요청 수량)
-        Order myOrder = request.toEntity(user, bunny);
-        orderRepository.save(myOrder);
+        Order myOrder = orderRepository.save(request.toEntity(user, bunny));
 
         // 매수 시 예약금(원금 + 수수료) 즉시 선차감
         if (myOrder.getOrderType() == OrderType.BUY) {
@@ -444,6 +444,13 @@ public class BunnyService {
                         .closingPrice(bunnyHistory.getClosingPrice())
                         .build())
                 .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public BadgeHolderListResponse getBadgeHolders(String badgeName) {
+        String badgeImg = badgeName.toUpperCase();
+        List<Bunny> bunnies = bunnyRepository.findAllByBadgeImg(badgeImg);
+        return BadgeHolderListResponse.from(badgeImg, bunnies);
     }
 
     private List<ComparisonData> getCompetitors(Bunny myBunny) {


### PR DESCRIPTION
## 📌 작업 개요
- 뱃지 별 보유자 목록 조회 API 구현

## 🎫 관련 이슈
- [RABBIT-155](https://dssw5.atlassian.net/browse/RABBIT-155)

## 🎬 참고 이미지
<img width="751" height="604" alt="image" src="https://github.com/user-attachments/assets/b8079ecd-771e-4c0a-8186-b717a8e7e55b" />

## 📎 기타
- 없음.